### PR TITLE
Use provider ID only

### DIFF
--- a/cloud-controller-manager/alicloud_test.go
+++ b/cloud-controller-manager/alicloud_test.go
@@ -21,6 +21,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
+	"testing"
+
 	"github.com/denverdino/aliyungo/common"
 	"github.com/denverdino/aliyungo/ecs"
 	"github.com/denverdino/aliyungo/metadata"
@@ -30,15 +33,18 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/kubernetes/pkg/cloudprovider"
-	"strings"
-	"testing"
 )
 
 var keyid string
 var keysecret string
 
 var (
+	vpcId             = "vpc-2zeaybwqmvn6qgabfd3pe"
 	vswitchid         = "vsw-2zeclpmxy66zzxj4cg4ls"
+	regionId          = "cn-beijing"
+	zoneId            = "cn-beijing-b"
+	certID            = "1745547945134207_157f665c830"
+	listenPort1 int32 = 80
 	listenPort2 int32 = 90
 	targetPort1       = intstr.FromInt(8080)
 	targetPort2       = intstr.FromInt(9090)
@@ -46,7 +52,7 @@ var (
 	nodePort2   int32 = 9090
 	protocolTcp       = v1.ProtocolTCP
 	protocolUdp       = v1.ProtocolUDP
-	node1             = "i-bp1bcl00jhxr754tw8vy"
+	node1             = "i-bp1bcl00jhxr754tw8vx"
 	node2             = "i-bp1bcl00jhxr754tw8vy"
 	clusterName       = "clusterName-random"
 	serviceUID        = "UID-1234567890-0987654321-1234556"
@@ -77,7 +83,7 @@ func newMockCloud(slb ClientSLBSDK, route RouteSDK, ins ClientInstanceSDK, meta 
 	if meta == nil {
 		meta = metadata.NewMockMetaData(nil, func(resource string) (string, error) {
 			if strings.Contains(resource, metadata.REGION) {
-				return "cn-beijing", nil
+				return regionId, nil
 			}
 			if strings.Contains(resource, metadata.VPC_ID) {
 				return vswitchid, nil
@@ -102,12 +108,10 @@ func newMockCloud(slb ClientSLBSDK, route RouteSDK, ins ClientInstanceSDK, meta 
 	return newAliCloud(mgr)
 }
 
-func TestEnsureLoadBalancerBasic(t *testing.T) {
-	instanceid := "i-2zecarjjmtkx3oru4233"
-	listenPort1 := int32(80)
-	service := &v1.Service{
+func newBasicService() *v1.Service {
+	return &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "my-service",
+			Name: "basic-service",
 			UID:  types.UID(serviceUID),
 		},
 		Spec: v1.ServiceSpec{
@@ -118,45 +122,152 @@ func TestEnsureLoadBalancerBasic(t *testing.T) {
 			SessionAffinity: v1.ServiceAffinityNone,
 		},
 	}
-	nodes := []*v1.Node{
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: nodeid("cn-beijing", instanceid)},
-			Spec: v1.NodeSpec{
-				ProviderID: nodeid("cn-beijing", instanceid),
+}
+func newHTTPSSerice() *v1.Service {
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "https-service",
+			UID:  types.UID(serviceUID),
+			Annotations: map[string]string{
+				ServiceAnnotationLoadBalancerProtocolPort: fmt.Sprintf("https:%d", listenPort1),
+				ServiceAnnotationLoadBalancerCertID:       certID,
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{Port: listenPort1, TargetPort: targetPort1, Protocol: v1.ProtocolTCP, NodePort: nodePort1},
+			},
+			Type:            v1.ServiceTypeLoadBalancer,
+			SessionAffinity: v1.ServiceAffinityNone,
+		},
+	}
+}
+func newPortRangeService() *v1.Service {
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "port-range-service",
+			UID:  types.UID(serviceUID),
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Port: listenPort1, TargetPort: targetPort1, Protocol: v1.ProtocolTCP, NodePort: nodePort1,
+				}, {
+					Port: 443, TargetPort: intstr.FromInt(443), Protocol: v1.ProtocolTCP, NodePort: 30443,
+				},
+			},
+			Type:            v1.ServiceTypeLoadBalancer,
+			SessionAffinity: v1.ServiceAffinityNone,
+		},
+	}
+}
+
+func newReadyService() *v1.Service {
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "my-service",
+			UID:         types.UID(serviceUID),
+			Annotations: map[string]string{
+			//ServiceAnnotationLoadBalancerId: "idbllll",
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{Port: listenPort1, TargetPort: targetPort1, Protocol: v1.ProtocolTCP, NodePort: nodePort1},
+			},
+			Type:            v1.ServiceTypeLoadBalancer,
+			SessionAffinity: v1.ServiceAffinityNone,
+		},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{
+					{
+						IP: "1.1.1.1",
+					},
+				},
 			},
 		},
 	}
+}
+func newNode1() *v1.Node {
+	return &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: node1},
+		Spec: v1.NodeSpec{
+			ProviderID: nodeid(regionId, node1),
+		},
+	}
+}
 
-	base := newBaseLoadbalancer()
-	detail := loadbalancerAttrib(&base[0])
-	t.Log(PrettyJson(detail))
-	// New Mock cloud to test
-	cloud, err := newMockCloud(&mockClientSLB{
+func newMockClientInstanceSDK(instanceid string) ClientInstanceSDK {
+	return &mockClientInstanceSDK{
+		describeInstances: func(args *ecs.DescribeInstancesArgs) (instances []ecs.InstanceAttributesType, pagination *common.PaginationResult, err error) {
+			if !strings.Contains(args.InstanceIds, instanceid) {
+				return nil, nil, errors.New("not found")
+			}
+			instances = []ecs.InstanceAttributesType{
+				{
+					InstanceId:          instanceid,
+					ImageId:             "centos_7_04_64_20G_alibase_201701015.vhd",
+					RegionId:            common.Region(regionId),
+					ZoneId:              zoneId,
+					InstanceType:        "ecs.sn1ne.large",
+					InstanceTypeFamily:  "ecs.sn1ne",
+					Status:              "running",
+					InstanceNetworkType: "vpc",
+					VpcAttributes: ecs.VpcAttributesType{
+						VpcId:     vpcId,
+						VSwitchId: vswitchid,
+						PrivateIpAddress: ecs.IpAddressSetType{
+							IpAddress: []string{"192.168.211.130"},
+						},
+					},
+					InstanceChargeType: common.PostPaid,
+				},
+			}
+			return instances, nil, nil
+		},
+	}
+
+}
+func newMockClientSLB(service *v1.Service, nodes []*v1.Node, base *[]slb.LoadBalancerType, detail *slb.LoadBalancerType) *mockClientSLB {
+	return &mockClientSLB{
 		describeLoadBalancers: func(args *slb.DescribeLoadBalancersArgs) (loadBalancers []slb.LoadBalancerType, err error) {
 
 			if args.LoadBalancerId != "" {
-				base[0].LoadBalancerId = args.LoadBalancerId
-				return base, nil
+				(*base)[0].LoadBalancerId = args.LoadBalancerId
+				return *base, nil
 			}
 			if args.LoadBalancerName != "" {
-				base[0].LoadBalancerName = args.LoadBalancerName
-				return base, nil
+				(*base)[0].LoadBalancerName = args.LoadBalancerName
+				return *base, nil
 			}
 			if len(args.Tags) > 0 {
-				base[0].LoadBalancerName = cloudprovider.GetLoadBalancerName(service)
+				(*base)[0].LoadBalancerName = cloudprovider.GetLoadBalancerName(service)
 			} else {
-				return nil, errors.New("loadbalancerid or loadbanancername must be specified.\n")
+				return nil, errors.New("loadbalancerid or loadbanancername must be specified")
 			}
-			return base, nil
+			return *base, nil
 		},
 		describeLoadBalancerAttribute: func(loadBalancerId string) (loadBalancer *slb.LoadBalancerType, err error) {
-			t.Logf("findloadbalancer, [%s]", loadBalancerId)
-			return loadbalancerAttrib(&base[0]), nil
+			return loadbalancerAttrib(&((*base)[0])), nil
 		},
 		createLoadBalancerTCPListener: func(args *slb.CreateLoadBalancerTCPListenerArgs) (err error) {
 			li := slb.ListenerPortAndProtocolType{
 				ListenerPort:     args.ListenerPort,
 				ListenerProtocol: "tcp",
+			}
+			detail.ListenerPorts.ListenerPort = append(detail.ListenerPorts.ListenerPort, args.ListenerPort)
+			detail.ListenerPortsAndProtocol.ListenerPortAndProtocol = append(detail.ListenerPortsAndProtocol.ListenerPortAndProtocol, li)
+			return nil
+		},
+		createLoadBalancerHTTPSListener: func(args *slb.CreateLoadBalancerHTTPSListenerArgs) (err error) {
+			// check certid
+			if args.ServerCertificateId != certID {
+				return fmt.Errorf("server cert must be provided and equals to [%s]", certID)
+			}
+			li := slb.ListenerPortAndProtocolType{
+				ListenerPort:     args.ListenerPort,
+				ListenerProtocol: "https",
 			}
 			detail.ListenerPorts.ListenerPort = append(detail.ListenerPorts.ListenerPort, args.ListenerPort)
 			detail.ListenerPortsAndProtocol.ListenerPortAndProtocol = append(detail.ListenerPortsAndProtocol.ListenerPortAndProtocol, li)
@@ -203,173 +314,6 @@ func TestEnsureLoadBalancerBasic(t *testing.T) {
 				}
 			}
 			return nil, errors.New("not found")
-		},
-		removeBackendServers: func(loadBalancerId string, backendServers []string) (result []slb.BackendServerType, err error) {
-			servers := detail.BackendServers.BackendServer
-			target := []slb.BackendServerType{}
-			for _, server := range servers {
-				found := false
-				for _, backendServer := range backendServers {
-					if server.ServerId == backendServer {
-						found = true
-					}
-				}
-				if !found {
-					target = append(target, server)
-				}
-			}
-			detail.BackendServers.BackendServer = target
-			return target, nil
-		},
-		addBackendServers: func(loadBalancerId string, backendServers []slb.BackendServerType) (result []slb.BackendServerType, err error) {
-			detail.BackendServers.BackendServer = append(detail.BackendServers.BackendServer, backendServers...)
-			return detail.BackendServers.BackendServer, nil
-		},
-	}, nil, &mockClientInstanceSDK{
-		describeInstances: func(args *ecs.DescribeInstancesArgs) (instances []ecs.InstanceAttributesType, pagination *common.PaginationResult, err error) {
-			if !strings.Contains(args.InstanceIds, instanceid) {
-				return nil, nil, errors.New("not found")
-			}
-			instances = []ecs.InstanceAttributesType{
-				{
-					InstanceId:          instanceid,
-					ImageId:             "centos_7_04_64_20G_alibase_201701015.vhd",
-					RegionId:            "cn-beijing",
-					ZoneId:              "cn-beijing-f",
-					InstanceType:        "ecs.sn1ne.large",
-					InstanceTypeFamily:  "ecs.sn1ne",
-					Status:              "running",
-					InstanceNetworkType: "vpc",
-					VpcAttributes: ecs.VpcAttributesType{
-						VpcId:     "vpc-2zeaybwqmvn6qgabfd3pe",
-						VSwitchId: "vsw-2zeclpmxy66zzxj4cg4ls",
-						PrivateIpAddress: ecs.IpAddressSetType{
-							IpAddress: []string{"192.168.211.130"},
-						},
-					},
-					InstanceChargeType: common.PostPaid,
-				},
-			}
-
-			return instances, nil, nil
-		},
-	}, nil)
-
-	if err != nil {
-		t.Fatal(fmt.Sprintf("TestEnsureLoadBalancer error newCloud: %s\n", err.Error()))
-	}
-
-	status, e := cloud.EnsureLoadBalancer(clusterName, service, nodes)
-	if e != nil {
-		t.Errorf("TestEnsureLoadBalancer error: %s\n", e.Error())
-	}
-	t.Log(PrettyJson(status))
-	t.Log(PrettyJson(detail))
-	if len(detail.BackendServers.BackendServer) != 1 {
-		t.Fatal("TestEnsureLoadBalancer error, expected only 1 backend left")
-	}
-	if detail.BackendServers.BackendServer[0].ServerId != instanceid {
-		t.Fatal(fmt.Sprintf("TestEnsureLoadBalancer error, expected to be instance [%s]", instanceid))
-	}
-	if len(detail.ListenerPorts.ListenerPort) != 1 {
-		t.Fatal("TestEnsureLoadBalancer error, expected only 1 listener port left")
-	}
-	if detail.ListenerPorts.ListenerPort[0] != 80 {
-		t.Fatal("TestEnsureLoadBalancer error, expected to be port 80")
-	}
-}
-
-// EnsureLoadBalancer and HTTPS with UpdateLoadBalancer.
-func TestEnsureLoadBalancerHTTPS(t *testing.T) {
-	instanceid := "i-2zecarjjmtkx3oru4233"
-	listenPort1 := int32(80)
-	certID := "1745547945134207_157f665c830"
-
-	service := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "my-service",
-			UID:  types.UID(serviceUID),
-			Annotations: map[string]string{
-				ServiceAnnotationLoadBalancerProtocolPort: fmt.Sprintf("https:%d", listenPort1),
-				ServiceAnnotationLoadBalancerCertID:       certID,
-			},
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{
-				{Port: listenPort1, TargetPort: targetPort1, Protocol: v1.ProtocolTCP, NodePort: nodePort1},
-			},
-			Type:            v1.ServiceTypeLoadBalancer,
-			SessionAffinity: v1.ServiceAffinityNone,
-		},
-	}
-	nodes := []*v1.Node{
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: nodeid("cn-beijing", instanceid)},
-			Spec: v1.NodeSpec{
-				ProviderID: nodeid("cn-beijing", instanceid),
-			},
-		},
-	}
-	base := newBaseLoadbalancer()
-	detail := loadbalancerAttrib(&base[0])
-	t.Log(PrettyJson(detail))
-	// New Mock cloud to test
-	cloud, err := newMockCloud(&mockClientSLB{
-		describeLoadBalancers: func(args *slb.DescribeLoadBalancersArgs) (loadBalancers []slb.LoadBalancerType, err error) {
-
-			if args.LoadBalancerId != "" {
-				base[0].LoadBalancerId = args.LoadBalancerId
-				return base, nil
-			}
-			if args.LoadBalancerName != "" {
-				base[0].LoadBalancerName = args.LoadBalancerName
-				return base, nil
-			}
-			if len(args.Tags) > 0 {
-				base[0].LoadBalancerName = cloudprovider.GetLoadBalancerName(service)
-			} else {
-				return nil, errors.New("loadbalancerid or loadbanancername must be specified.\n")
-			}
-			return base, nil
-		},
-		describeLoadBalancerAttribute: func(loadBalancerId string) (loadBalancer *slb.LoadBalancerType, err error) {
-			t.Logf("findloadbalancer, [%s]", loadBalancerId)
-			return loadbalancerAttrib(&base[0]), nil
-		},
-		createLoadBalancerHTTPSListener: func(args *slb.CreateLoadBalancerHTTPSListenerArgs) (err error) {
-			// check certid
-			if args.ServerCertificateId != certID {
-				return fmt.Errorf("server cert must be provided and equals to [%s]", certID)
-			}
-			li := slb.ListenerPortAndProtocolType{
-				ListenerPort:     args.ListenerPort,
-				ListenerProtocol: "https",
-			}
-			detail.ListenerPorts.ListenerPort = append(detail.ListenerPorts.ListenerPort, args.ListenerPort)
-			detail.ListenerPortsAndProtocol.ListenerPortAndProtocol = append(detail.ListenerPortsAndProtocol.ListenerPortAndProtocol, li)
-			return nil
-		},
-		deleteLoadBalancerListener: func(loadBalancerId string, port int) (err error) {
-			response := []slb.ListenerPortAndProtocolType{}
-			ports := detail.ListenerPortsAndProtocol.ListenerPortAndProtocol
-			for _, p := range ports {
-				if p.ListenerPort == port {
-					continue
-				}
-				response = append(response, p)
-			}
-
-			listports := []int{}
-			lports := detail.ListenerPorts.ListenerPort
-			for _, po := range lports {
-				if po == port {
-					continue
-				}
-				listports = append(listports, po)
-			}
-			detail.ListenerPortsAndProtocol.ListenerPortAndProtocol = response
-			detail.ListenerPorts.ListenerPort = listports
-			return nil
 		},
 		describeLoadBalancerHTTPSListenerAttribute: func(loadBalancerId string, port int) (response *slb.DescribeLoadBalancerHTTPSListenerAttributeResponse, err error) {
 			ports := detail.ListenerPortsAndProtocol.ListenerPortAndProtocol
@@ -415,35 +359,59 @@ func TestEnsureLoadBalancerHTTPS(t *testing.T) {
 			detail.BackendServers.BackendServer = append(detail.BackendServers.BackendServer, backendServers...)
 			return detail.BackendServers.BackendServer, nil
 		},
-	}, nil, &mockClientInstanceSDK{
-		describeInstances: func(args *ecs.DescribeInstancesArgs) (instances []ecs.InstanceAttributesType, pagination *common.PaginationResult, err error) {
-			if !strings.Contains(args.InstanceIds, instanceid) {
-				return nil, nil, errors.New("not found")
-			}
-			instances = []ecs.InstanceAttributesType{
-				{
-					InstanceId:          instanceid,
-					ImageId:             "centos_7_04_64_20G_alibase_201701015.vhd",
-					RegionId:            "cn-beijing",
-					ZoneId:              "cn-beijing-f",
-					InstanceType:        "ecs.sn1ne.large",
-					InstanceTypeFamily:  "ecs.sn1ne",
-					Status:              "running",
-					InstanceNetworkType: "vpc",
-					VpcAttributes: ecs.VpcAttributesType{
-						VpcId:     "vpc-2zeaybwqmvn6qgabfd3pe",
-						VSwitchId: "vsw-2zeclpmxy66zzxj4cg4ls",
-						PrivateIpAddress: ecs.IpAddressSetType{
-							IpAddress: []string{"192.168.211.130"},
-						},
-					},
-					InstanceChargeType: common.PostPaid,
-				},
-			}
-
-			return instances, nil, nil
+		deleteLoadBalancer: func(loadBalancerId string) (err error) {
+			*base = []slb.LoadBalancerType{}
+			return nil
 		},
-	}, nil)
+	}
+}
+func TestEnsureLoadBalancerBasic(t *testing.T) {
+	service := newBasicService()
+	nodes := []*v1.Node{
+		newNode1(),
+	}
+	base := newBaseLoadbalancer()
+	detail := loadbalancerAttrib(&base[0])
+	t.Log(PrettyJson(detail))
+
+	// New Mock cloud to test
+	cloud, err := newMockCloud(newMockClientSLB(service, nodes, &base, detail), nil, newMockClientInstanceSDK(node1), nil)
+
+	if err != nil {
+		t.Fatal(fmt.Sprintf("TestEnsureLoadBalancer error newCloud: %s\n", err.Error()))
+	}
+
+	status, e := cloud.EnsureLoadBalancer(clusterName, service, nodes)
+	if e != nil {
+		t.Errorf("TestEnsureLoadBalancer error: %s\n", e.Error())
+	}
+	t.Log(PrettyJson(status))
+	t.Log(PrettyJson(detail))
+	if len(detail.BackendServers.BackendServer) != 1 {
+		t.Fatal("TestEnsureLoadBalancer error, expected only 1 backend left")
+	}
+	if detail.BackendServers.BackendServer[0].ServerId != node1 {
+		t.Fatal(fmt.Sprintf("TestEnsureLoadBalancer error, expected to be instance [%s]", node1))
+	}
+	if len(detail.ListenerPorts.ListenerPort) != 1 {
+		t.Fatal("TestEnsureLoadBalancer error, expected only 1 listener port left")
+	}
+	if detail.ListenerPorts.ListenerPort[0] != 80 {
+		t.Fatal("TestEnsureLoadBalancer error, expected to be port 80")
+	}
+}
+
+// EnsureLoadBalancer and HTTPS with UpdateLoadBalancer.
+func TestEnsureLoadBalancerHTTPS(t *testing.T) {
+	service := newHTTPSSerice()
+	nodes := []*v1.Node{
+		newNode1(),
+	}
+	base := newBaseLoadbalancer()
+	detail := loadbalancerAttrib(&base[0])
+	t.Log(PrettyJson(detail))
+	// New Mock cloud to test
+	cloud, err := newMockCloud(newMockClientSLB(service, nodes, &base, detail), nil, newMockClientInstanceSDK(node1), nil)
 
 	if err != nil {
 		t.Fatal(fmt.Sprintf("TestEnsureLoadBalancer error newCloud: %s\n", err.Error()))
@@ -463,161 +431,16 @@ func TestEnsureLoadBalancerHTTPS(t *testing.T) {
 }
 
 func TestEnsureLoadBalancerWithPortChange(t *testing.T) {
-	instanceid := "i-2zecarjjmtkx3oru4233"
-	listenPort1 := int32(80)
-	service := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "my-service",
-			UID:  types.UID(serviceUID),
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{
-				{
-					Port: listenPort1, TargetPort: targetPort1, Protocol: v1.ProtocolTCP, NodePort: nodePort1,
-				}, {
-					Port: 443, TargetPort: intstr.FromInt(443), Protocol: v1.ProtocolTCP, NodePort: 30443,
-				},
-			},
-			Type:            v1.ServiceTypeLoadBalancer,
-			SessionAffinity: v1.ServiceAffinityNone,
-		},
-	}
+	service := newPortRangeService()
 	nodes := []*v1.Node{
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: nodeid("cn-beijing", instanceid)},
-			Spec: v1.NodeSpec{
-				ProviderID: nodeid("cn-beijing", instanceid),
-			},
-		},
+		newNode1(),
 	}
 
 	base := newBaseLoadbalancer()
 	detail := loadbalancerAttrib(&base[0])
 	t.Log(PrettyJson(detail))
 	// New Mock cloud to test
-	cloud, err := newMockCloud(&mockClientSLB{
-		describeLoadBalancers: func(args *slb.DescribeLoadBalancersArgs) (loadBalancers []slb.LoadBalancerType, err error) {
-
-			if args.LoadBalancerId != "" {
-				base[0].LoadBalancerId = args.LoadBalancerId
-				return base, nil
-			}
-			if args.LoadBalancerName != "" {
-				base[0].LoadBalancerName = args.LoadBalancerName
-				return base, nil
-			}
-			if len(args.Tags) > 0 {
-				base[0].LoadBalancerName = cloudprovider.GetLoadBalancerName(service)
-			} else {
-				return nil, errors.New("loadbalancerid or loadbanancername must be specified.\n")
-			}
-			return base, nil
-		},
-		describeLoadBalancerAttribute: func(loadBalancerId string) (loadBalancer *slb.LoadBalancerType, err error) {
-			t.Logf("findloadbalancer, [%s]", loadBalancerId)
-			return loadbalancerAttrib(&base[0]), nil
-		},
-		createLoadBalancerTCPListener: func(args *slb.CreateLoadBalancerTCPListenerArgs) (err error) {
-			li := slb.ListenerPortAndProtocolType{
-				ListenerPort:     args.ListenerPort,
-				ListenerProtocol: "tcp",
-			}
-			detail.ListenerPorts.ListenerPort = append(detail.ListenerPorts.ListenerPort, args.ListenerPort)
-			detail.ListenerPortsAndProtocol.ListenerPortAndProtocol = append(detail.ListenerPortsAndProtocol.ListenerPortAndProtocol, li)
-			return nil
-		},
-		deleteLoadBalancerListener: func(loadBalancerId string, port int) (err error) {
-			response := []slb.ListenerPortAndProtocolType{}
-			ports := detail.ListenerPortsAndProtocol.ListenerPortAndProtocol
-			for _, p := range ports {
-				if p.ListenerPort == port {
-					continue
-				}
-				response = append(response, p)
-			}
-
-			listports := []int{}
-			lports := detail.ListenerPorts.ListenerPort
-			for _, po := range lports {
-				if po == port {
-					continue
-				}
-				listports = append(listports, po)
-			}
-			detail.ListenerPortsAndProtocol.ListenerPortAndProtocol = response
-			detail.ListenerPorts.ListenerPort = listports
-			return nil
-		},
-		describeLoadBalancerTCPListenerAttribute: func(loadBalancerId string, port int) (response *slb.DescribeLoadBalancerTCPListenerAttributeResponse, err error) {
-			ports := detail.ListenerPortsAndProtocol.ListenerPortAndProtocol
-
-			for _, p := range ports {
-				if p.ListenerPort == port {
-					return &slb.DescribeLoadBalancerTCPListenerAttributeResponse{
-						DescribeLoadBalancerListenerAttributeResponse: slb.DescribeLoadBalancerListenerAttributeResponse{
-							Status: slb.Running,
-						},
-						TCPListenerType: slb.TCPListenerType{
-							LoadBalancerId:    loadBalancerId,
-							ListenerPort:      port,
-							BackendServerPort: 31789,
-							Bandwidth:         50,
-						},
-					}, nil
-				}
-			}
-			return nil, errors.New("not found")
-		},
-		removeBackendServers: func(loadBalancerId string, backendServers []string) (result []slb.BackendServerType, err error) {
-			servers := detail.BackendServers.BackendServer
-			target := []slb.BackendServerType{}
-			for _, server := range servers {
-				found := false
-				for _, backendServer := range backendServers {
-					if server.ServerId == backendServer {
-						found = true
-					}
-				}
-				if !found {
-					target = append(target, server)
-				}
-			}
-			detail.BackendServers.BackendServer = target
-			return target, nil
-		},
-		addBackendServers: func(loadBalancerId string, backendServers []slb.BackendServerType) (result []slb.BackendServerType, err error) {
-			detail.BackendServers.BackendServer = append(detail.BackendServers.BackendServer, backendServers...)
-			return detail.BackendServers.BackendServer, nil
-		},
-	}, nil, &mockClientInstanceSDK{
-		describeInstances: func(args *ecs.DescribeInstancesArgs) (instances []ecs.InstanceAttributesType, pagination *common.PaginationResult, err error) {
-			if !strings.Contains(args.InstanceIds, instanceid) {
-				return nil, nil, errors.New("not found")
-			}
-			instances = []ecs.InstanceAttributesType{
-				{
-					InstanceId:          instanceid,
-					ImageId:             "centos_7_04_64_20G_alibase_201701015.vhd",
-					RegionId:            "cn-beijing",
-					ZoneId:              "cn-beijing-f",
-					InstanceType:        "ecs.sn1ne.large",
-					InstanceTypeFamily:  "ecs.sn1ne",
-					Status:              "running",
-					InstanceNetworkType: "vpc",
-					VpcAttributes: ecs.VpcAttributesType{
-						VpcId:     "vpc-2zeaybwqmvn6qgabfd3pe",
-						VSwitchId: "vsw-2zeclpmxy66zzxj4cg4ls",
-						PrivateIpAddress: ecs.IpAddressSetType{
-							IpAddress: []string{"192.168.211.130"},
-						},
-					},
-					InstanceChargeType: common.PostPaid,
-				},
-			}
-
-			return instances, nil, nil
-		},
-	}, nil)
+	cloud, err := newMockCloud(newMockClientSLB(service, nodes, &base, detail), nil, newMockClientInstanceSDK(node1), nil)
 
 	if err != nil {
 		t.Fatal(fmt.Sprintf("TestEnsureLoadBalancer error newCloud: %s\n", err.Error()))
@@ -632,8 +455,8 @@ func TestEnsureLoadBalancerWithPortChange(t *testing.T) {
 	if len(detail.BackendServers.BackendServer) != 1 {
 		t.Fatal("TestEnsureLoadBalancerWithPortChange error, expected only 1 backend left")
 	}
-	if detail.BackendServers.BackendServer[0].ServerId != instanceid {
-		t.Fatal(fmt.Sprintf("TestEnsureLoadBalancerWithPortChange error, expected to be instance [%s]", instanceid))
+	if detail.BackendServers.BackendServer[0].ServerId != node1 {
+		t.Fatal(fmt.Sprintf("TestEnsureLoadBalancerWithPortChange error, expected to be instance [%s]", node1))
 	}
 	if len(detail.ListenerPorts.ListenerPort) != 2 {
 		t.Fatal("TestEnsureLoadBalancerWithPortChange error, expected only 1 listener port left")
@@ -687,82 +510,11 @@ func TestEnsureLoadBalancerWithPortChange(t *testing.T) {
 //
 
 func TestEnsureLoadbalancerDeleted(t *testing.T) {
-	instanceid := "i-2zecarjjmtkx3oru4233"
-
-	service := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "my-service",
-			UID:  types.UID(serviceUID),
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{
-				{Port: listenPort2, TargetPort: targetPort2, Protocol: v1.ProtocolTCP, NodePort: nodePort2},
-			},
-			Type:            v1.ServiceTypeLoadBalancer,
-			SessionAffinity: v1.ServiceAffinityNone,
-		},
-	}
+	service := newReadyService()
 
 	base := newBaseLoadbalancer()
 	// New Mock cloud to test
-	cloud, err := newMockCloud(&mockClientSLB{
-		describeLoadBalancers: func(args *slb.DescribeLoadBalancersArgs) (loadBalancers []slb.LoadBalancerType, err error) {
-
-			if args.LoadBalancerId != "" {
-				base[0].LoadBalancerId = args.LoadBalancerId
-				return base, nil
-			}
-			if args.LoadBalancerName != "" {
-				base[0].LoadBalancerName = args.LoadBalancerName
-				return base, nil
-			}
-			if len(args.Tags) > 0 {
-				base[0].LoadBalancerName = cloudprovider.GetLoadBalancerName(service)
-			} else {
-				return nil, errors.New("loadbalancerid or loadbanancername must be specified.\n")
-			}
-			return base, nil
-		},
-		describeLoadBalancerAttribute: func(loadBalancerId string) (loadBalancer *slb.LoadBalancerType, err error) {
-			t.Logf("findloadbalancer, [%s]", loadBalancerId)
-			return loadbalancerAttrib(&base[0]), nil
-		},
-		deleteLoadBalancer: func(loadBalancerId string) (err error) {
-			if loadBalancerId != base[0].LoadBalancerId {
-				return errors.New("loadbalancer not found")
-			}
-			base = []slb.LoadBalancerType{}
-			return nil
-		},
-	}, nil, &mockClientInstanceSDK{
-		describeInstances: func(args *ecs.DescribeInstancesArgs) (instances []ecs.InstanceAttributesType, pagination *common.PaginationResult, err error) {
-			if !strings.Contains(args.InstanceIds, instanceid) {
-				return nil, nil, errors.New("not found")
-			}
-			instances = []ecs.InstanceAttributesType{
-				{
-					InstanceId:          instanceid,
-					ImageId:             "centos_7_04_64_20G_alibase_201701015.vhd",
-					RegionId:            "cn-beijing",
-					ZoneId:              "cn-beijing-f",
-					InstanceType:        "ecs.sn1ne.large",
-					InstanceTypeFamily:  "ecs.sn1ne",
-					Status:              "running",
-					InstanceNetworkType: "vpc",
-					VpcAttributes: ecs.VpcAttributesType{
-						VpcId:     "vpc-2zeaybwqmvn6qgabfd3pe",
-						VSwitchId: "vsw-2zeclpmxy66zzxj4cg4ls",
-						PrivateIpAddress: ecs.IpAddressSetType{
-							IpAddress: []string{"192.168.211.130"},
-						},
-					},
-					InstanceChargeType: common.PostPaid,
-				},
-			}
-
-			return instances, nil, nil
-		},
-	}, nil)
+	cloud, err := newMockCloud(newMockClientSLB(service, nil, &base, nil), nil, newMockClientInstanceSDK(node1), nil)
 
 	if err != nil {
 		t.Errorf("TestEnsureLoadbalancerDeleted error newCloud: %s\n", err.Error())
@@ -781,63 +533,11 @@ func TestEnsureLoadbalancerDeleted(t *testing.T) {
 }
 
 func TestEnsureLoadBalancerDeleteWithUserDefined(t *testing.T) {
-	listenPort1 := int32(80)
 	base := newBaseLoadbalancer()
-	service := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        "my-service",
-			UID:         types.UID(serviceUID),
-			Annotations: map[string]string{
-				//ServiceAnnotationLoadBalancerId: "idbllll",
-			},
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{
-				{Port: listenPort1, TargetPort: targetPort1, Protocol: v1.ProtocolTCP, NodePort: nodePort1},
-			},
-			Type:            v1.ServiceTypeLoadBalancer,
-			SessionAffinity: v1.ServiceAffinityNone,
-		},
-		Status: v1.ServiceStatus{
-			LoadBalancer: v1.LoadBalancerStatus{
-				Ingress: []v1.LoadBalancerIngress{
-					{
-						IP: "1.1.1.1",
-					},
-				},
-			},
-		},
-	}
+	service := newReadyService()
 	t.Log(PrettyJson(base))
 	// New Mock cloud to test
-	cloud, err := newMockCloud(&mockClientSLB{
-		describeLoadBalancers: func(args *slb.DescribeLoadBalancersArgs) (loadBalancers []slb.LoadBalancerType, err error) {
-
-			if args.LoadBalancerId != "" {
-				base[0].LoadBalancerId = args.LoadBalancerId
-				return base, nil
-			}
-			if args.LoadBalancerName != "" {
-				base[0].LoadBalancerName = args.LoadBalancerName
-				return base, nil
-			}
-			if len(args.Tags) > 0 {
-				base[0].LoadBalancerName = cloudprovider.GetLoadBalancerName(service)
-			} else {
-				return nil, errors.New("loadbalancerid or loadbanancername must be specified.\n")
-			}
-			return base, nil
-		},
-		describeLoadBalancerAttribute: func(loadBalancerId string) (loadBalancer *slb.LoadBalancerType, err error) {
-			t.Logf("findloadbalancer, [%s]", loadBalancerId)
-			return loadbalancerAttrib(&base[0]), nil
-		},
-		deleteLoadBalancer: func(loadBalancerId string) (err error) {
-			base = []slb.LoadBalancerType{}
-			return nil
-		},
-	}, nil, nil, nil)
-
+	cloud, err := newMockCloud(newMockClientSLB(service, nil, &base, nil), nil, nil, nil)
 	if err != nil {
 		t.Fatal(fmt.Sprintf("TestEnsureLoadBalancerDeleteWithUserDefined error newCloud: %s\n", err.Error()))
 	}
@@ -853,43 +553,14 @@ func TestEnsureLoadBalancerDeleteWithUserDefined(t *testing.T) {
 }
 
 func TestNodeAddressAndInstanceID(t *testing.T) {
-	instanceid := "i-2zecarjjmtkx3oru4233"
 	// New Mock cloud to test
-	cloud, err := newMockCloud(nil, nil, &mockClientInstanceSDK{
-		describeInstances: func(args *ecs.DescribeInstancesArgs) (instances []ecs.InstanceAttributesType, pagination *common.PaginationResult, err error) {
-			if !strings.Contains(args.InstanceIds, instanceid) {
-				return nil, nil, errors.New("not found")
-			}
-			instances = []ecs.InstanceAttributesType{
-				{
-					InstanceId:          instanceid,
-					ImageId:             "centos_7_04_64_20G_alibase_201701015.vhd",
-					RegionId:            "cn-beijing",
-					ZoneId:              "cn-beijing-f",
-					InstanceType:        "ecs.sn1ne.large",
-					InstanceTypeFamily:  "ecs.sn1ne",
-					Status:              "running",
-					InstanceNetworkType: "vpc",
-					VpcAttributes: ecs.VpcAttributesType{
-						VpcId:     "vpc-2zeaybwqmvn6qgabfd3pe",
-						VSwitchId: "vsw-2zeclpmxy66zzxj4cg4ls",
-						PrivateIpAddress: ecs.IpAddressSetType{
-							IpAddress: []string{"192.168.211.130"},
-						},
-					},
-					InstanceChargeType: common.PostPaid,
-				},
-			}
-
-			return instances, nil, nil
-		},
-	}, nil)
+	cloud, err := newMockCloud(nil, nil, newMockClientInstanceSDK(node1), nil)
 
 	if err != nil {
 		t.Errorf("TestNodeAddressAndInstanceID error: newcloud %s\n", err.Error())
 	}
-	nodeName := nodeid("cn-beijing", instanceid)
-	n, e := cloud.NodeAddresses(types.NodeName(nodeName))
+	providerID := nodeid(regionId, node1)
+	n, e := cloud.NodeAddresses(types.NodeName(providerID))
 	if e != nil {
 		t.Errorf("TestNodeAddressAndInstanceID error: node address %s\n", e.Error())
 	}
@@ -901,14 +572,34 @@ func TestNodeAddressAndInstanceID(t *testing.T) {
 	if n[0].Type != "InternalIP" || n[0].Address != "192.168.211.130" {
 		t.Fatal("TestNodeAddressAndInstanceID error: node address must equal to 192.168.211.130 InternalIP")
 	}
-	id, err := cloud.InstanceID(types.NodeName(nodeName))
+
+	n, e = cloud.NodeAddressesByProviderID(providerID)
+	if e != nil {
+		t.Errorf("TestNodeAddressAndInstanceID error: node address %s\n", e.Error())
+	}
+	if len(n) != 1 {
+		t.Fatal("TestNodeAddressAndInstanceID error: node address returned must equal to 1")
+	}
+	if n[0].Type != "InternalIP" || n[0].Address != "192.168.211.130" {
+		t.Fatal("TestNodeAddressAndInstanceID error: node address must equal to 192.168.211.130 InternalIP")
+	}
+
+	id, err := cloud.InstanceID(types.NodeName(providerID))
 	if err != nil {
 		t.Errorf("TestNodeAddressAndInstanceID error: instanceid %s\n", err.Error())
 	}
 	t.Log(id)
-	if id != "i-2zecarjjmtkx3oru4233" {
-		t.Fatal("TestNodeAddressAndInstanceID error: instance id must equal to i-2zecarjjmtkx3oru4233")
+	if id != node1 {
+		t.Fatalf("TestNodeAddressAndInstanceID error: instance id must equal to %s" + node1)
 	}
+	iType, err := cloud.InstanceTypeByProviderID(providerID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if "ecs.sn1ne.large" != iType {
+		t.Fatalf("TestNodeAddressAndInstanceID error: instance type should be %s", "ecs.sn1ne.large")
+	}
+
 }
 
 var con string = `

--- a/cloud-controller-manager/instance_test.go
+++ b/cloud-controller-manager/instance_test.go
@@ -19,11 +19,11 @@ package alicloud
 import (
 	"errors"
 	"fmt"
-	"github.com/denverdino/aliyungo/common"
-	"github.com/denverdino/aliyungo/ecs"
-	"k8s.io/apimachinery/pkg/types"
 	"strings"
 	"testing"
+
+	"github.com/denverdino/aliyungo/common"
+	"github.com/denverdino/aliyungo/ecs"
 )
 
 func NewMockClientInstanceMgr(client ClientInstanceSDK) (*ClientMgr, error) {
@@ -71,14 +71,14 @@ func TestInstanceRefeshInstance(t *testing.T) {
 	if err != nil {
 		t.Fatal(fmt.Sprintf("create client manager fail. [%s]\n", err.Error()))
 	}
-	ins, err := mgr.Instances().refreshInstance(types.NodeName(id), common.Beijing)
+	ins, err := mgr.Instances().refreshInstance(instanceid, common.Beijing)
 	if err != nil {
 		t.Errorf("TestInstanceRefeshInstance error: %s\n", err.Error())
 	}
 	if ins.InstanceId != instanceid {
 		t.Fatal("refresh instance error.")
 	}
-	ins, err = mgr.Instances().findInstanceByNode(types.NodeName(id))
+	ins, err = mgr.Instances().findInstanceByProviderID(id)
 	if err != nil {
 		t.Fatal(fmt.Sprintf("findInstanceByNode error: %s\n", err.Error()))
 	}

--- a/cloud-controller-manager/instances.go
+++ b/cloud-controller-manager/instances.go
@@ -19,14 +19,15 @@ package alicloud
 import (
 	"errors"
 	"fmt"
+	"strings"
+	"sync"
+
 	"github.com/denverdino/aliyungo/common"
 	"github.com/denverdino/aliyungo/ecs"
 	"github.com/golang/glog"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/cloudprovider"
-	"strings"
-	"sync"
 )
 
 type InstanceClient struct {
@@ -46,7 +47,7 @@ func (s *InstanceClient) filterOutByRegion(nodes []*v1.Node, region common.Regio
 	result := []*v1.Node{}
 	mvpc := make(map[string]int)
 	for _, node := range nodes {
-		v, err := s.findInstanceByNode(types.NodeName(node.Name))
+		v, err := s.findInstanceByProviderID(node.Spec.ProviderID)
 		if err != nil {
 			return []*v1.Node{}, err
 		}
@@ -63,7 +64,7 @@ func (s *InstanceClient) filterOutByRegion(nodes []*v1.Node, region common.Regio
 	}
 	records := []string{}
 	for _, node := range nodes {
-		v, err := s.findInstanceByNode(types.NodeName(node.Name))
+		v, err := s.findInstanceByProviderID(node.Spec.ProviderID)
 		if err != nil {
 			glog.Errorf("alicloud: error find instance by node, retrieve nodes [%s]\n", err.Error())
 			return []*v1.Node{}, err
@@ -109,15 +110,13 @@ func (s *InstanceClient) filterOutByLabel(nodes []*v1.Node, labels string) ([]*v
 	return result, nil
 }
 
-// we use '.' separated nodeid which looks like 'cn-hangzhou.i-v98dklsmnxkkgiiil7' to identify node
-// This is the format of "REGION.NODEID"
-func nodeinfo(nodename types.NodeName) (common.Region, types.NodeName, error) {
-	name := strings.Split(string(nodename), ".")
+// Use '.' to separate providerID which looks like 'cn-hangzhou.i-v98dklsmnxkkgiiil7'. The format of "REGION.NODEID"
+func nodeFromProviderID(providerID string) (common.Region, string, error) {
+	name := strings.Split(providerID, ".")
 	if len(name) < 2 {
-		glog.Warningf("alicloud: unable to split instanceid and region from nodename, error unexpected nodename=%s \n", nodename)
-		return "", "", fmt.Errorf("alicloud: unable to split instanceid and region from nodename, error unexpected nodename=%s \n", nodename)
+		return "", "", fmt.Errorf("alicloud: unable to split instanceid and region from providerID, error unexpected providerID=%s", providerID)
 	}
-	return common.Region(name[0]), types.NodeName(name[1]), nil
+	return common.Region(name[0]), name[1], nil
 }
 
 // we use '.' separated nodeid which looks like 'cn-hangzhou.i-v98dklsmnxkkgiiil7' to identify node
@@ -126,15 +125,18 @@ func nodeid(region, nodename string) string {
 	return fmt.Sprintf("%s.%s", region, nodename)
 }
 
-// getAddressesByName return an instance address slice by it's name.
-func (s *InstanceClient) findAddress(nodeName types.NodeName) ([]v1.NodeAddress, error) {
-
-	instance, err := s.findInstanceByNode(nodeName)
+// findAddressByNodeName returns an address slice by it's host name.
+func (s *InstanceClient) findAddressByNodeName(nodeName types.NodeName) ([]v1.NodeAddress, error) {
+	instance, err := s.findInstanceByNodeName(nodeName)
 	if err != nil {
-		glog.Errorf("alicloud: error getting instance by instanceid. instanceid='%s', message=[%s]\n", nodeName, err.Error())
+		glog.Errorf("alicloud: error getting instance by nodeName. providerID='%s', message=[%s]\n", nodeName, err.Error())
 		return nil, err
 	}
 
+	return s.findAddressByInstance(instance)
+}
+
+func (s *InstanceClient) findAddressByInstance(instance *ecs.InstanceAttributesType) ([]v1.NodeAddress, error) {
 	addrs := []v1.NodeAddress{}
 
 	if len(instance.PublicIpAddress.IpAddress) > 0 {
@@ -166,34 +168,49 @@ func (s *InstanceClient) findAddress(nodeName types.NodeName) ([]v1.NodeAddress,
 	return addrs, nil
 }
 
-// nodeName must be a '.' separated Region and ndoeid string which is the instance identity
-// Returns instance information
-func (s *InstanceClient) findInstanceByNode(nodeName types.NodeName) (*ecs.InstanceAttributesType, error) {
-	region, nodeid, err := nodeinfo(nodeName)
+// findAddressByProviderID returns an address slice by it's providerID.
+func (s *InstanceClient) findAddressByProviderID(providerID string) ([]v1.NodeAddress, error) {
+
+	instance, err := s.findInstanceByProviderID(providerID)
+	if err != nil {
+		glog.Errorf("alicloud: error getting instance by providerID. providerID='%s', message=[%s]\n", providerID, err.Error())
+		return nil, err
+	}
+
+	return s.findAddressByInstance(instance)
+}
+
+// Returns instance information. Currently, we had a constraint that the name should has the same as provider id for compatibility concern.
+func (s *InstanceClient) findInstanceByNodeName(nodeName types.NodeName) (*ecs.InstanceAttributesType, error) {
+	return s.findInstanceByProviderID(string(nodeName))
+}
+
+func (s *InstanceClient) findInstanceByProviderID(providerID string) (*ecs.InstanceAttributesType, error) {
+	region, nodeid, err := nodeFromProviderID(providerID)
 	if err != nil {
 		return nil, err
 	}
-	return s.refreshInstance(types.NodeName(nodeid), common.Region(region))
+	return s.refreshInstance(nodeid, common.Region(region))
 }
 
-func (s *InstanceClient) refreshInstance(nodeName types.NodeName, region common.Region) (*ecs.InstanceAttributesType, error) {
+func (s *InstanceClient) refreshInstance(nodeID string, region common.Region) (*ecs.InstanceAttributesType, error) {
 	args := ecs.DescribeInstancesArgs{
 		RegionId:    region,
-		InstanceIds: fmt.Sprintf("[\"%s\"]", string(nodeName)),
+		InstanceIds: fmt.Sprintf("[\"%s\"]", nodeID),
 	}
 
 	instances, _, err := s.c.DescribeInstances(&args)
 	if err != nil {
-		glog.Errorf("alicloud: calling DescribeInstances error. region=%s, instancename=%s, message=[%s]\n", args.RegionId, args.InstanceName, err.Error())
+		glog.Errorf("alicloud: calling DescribeInstances error. region=%s, instancename=%s, message=[%s].\n", args.RegionId, args.InstanceName, err.Error())
 		return nil, err
 	}
 
 	if len(instances) == 0 {
-		glog.Infof("alicloud: InstanceNotFound, instanceid=[%s.%s]. It is likely to be deleted.", region, nodeName)
+		glog.Infof("alicloud: InstanceNotFound, instanceid=[%s.%s]. It is likely to be deleted.\n", region, nodeID)
 		return nil, cloudprovider.InstanceNotFound
 	}
 	if len(instances) > 1 {
-		glog.Warningf("alicloud: multipul instance found by nodename=[%s], the first one will be used, instanceid=[%s]", string(nodeName), instances[0].InstanceId)
+		glog.Warningf("alicloud: multipul instance found by nodename=[%s], the first one will be used, instanceid=[%s]\n", string(nodeID), instances[0].InstanceId)
 	}
 	return &instances[0], nil
 }

--- a/cloud-controller-manager/loadbalancer.go
+++ b/cloud-controller-manager/loadbalancer.go
@@ -23,11 +23,11 @@ import (
 	"strings"
 
 	"encoding/json"
+
 	"github.com/denverdino/aliyungo/common"
 	"github.com/denverdino/aliyungo/slb"
 	"github.com/golang/glog"
 	"k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 )
 
@@ -446,14 +446,14 @@ func (s *LoadBalancerClient) UpdateBackendServers(nodes []*v1.Node, lb *slb.Load
 	// checkout for newly added servers
 	for _, n1 := range nodes {
 		found := false
-		_, id, err := nodeinfo(types.NodeName(n1.Spec.ProviderID))
+		_, id, err := nodeFromProviderID(n1.Spec.ProviderID)
 		for _, n2 := range lb.BackendServers.BackendServer {
 			if err != nil {
 				glog.Errorf("alicloud: node providerid=%s is not"+
 					" in the correct form, expect regionid.instanceid. skip add op", n1.Spec.ProviderID)
 				continue
 			}
-			if string(id) == n2.ServerId {
+			if id == n2.ServerId {
 				found = true
 				break
 			}
@@ -486,13 +486,13 @@ func (s *LoadBalancerClient) UpdateBackendServers(nodes []*v1.Node, lb *slb.Load
 	for _, n1 := range lb.BackendServers.BackendServer {
 		found := false
 		for _, n2 := range nodes {
-			_, id, err := nodeinfo(types.NodeName(n2.Spec.ProviderID))
+			_, id, err := nodeFromProviderID(n2.Spec.ProviderID)
 			if err != nil {
 				glog.Errorf("alicloud: node providerid=%s is not "+
 					"in the correct form, expect regionid.instanceid.. skip delete op... [%s]", n2.Spec.ProviderID, err.Error())
 				continue
 			}
-			if n1.ServerId == string(id) {
+			if n1.ServerId == id {
 				found = true
 				break
 			}

--- a/cloud-controller-manager/routes.go
+++ b/cloud-controller-manager/routes.go
@@ -20,14 +20,15 @@ import (
 	"k8s.io/kubernetes/pkg/cloudprovider"
 
 	"fmt"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/denverdino/aliyungo/common"
 	"github.com/denverdino/aliyungo/ecs"
 	"github.com/golang/glog"
 	"github.com/patrickmn/go-cache"
 	"k8s.io/apimachinery/pkg/types"
-	"strings"
-	"sync"
-	"time"
 )
 
 type RoutesClient struct {
@@ -84,8 +85,7 @@ func (r *RoutesClient) findRouter(region common.Region, vpcid string) (*ecs.VRou
 			return nil, err
 		}
 		if len(vroute) <= 0 {
-			return nil, fmt.Errorf("can not find VRouter metadata "+
-				"by instance. region=%s,vpcid=%v, error=[no VRouter found by specified id]", region, vpc)
+			return nil, fmt.Errorf("can not find VRouter metadata by instance. region=%s,vpcid=%s, error=[no VRouter found by specified id]", region, vpc.VpcId)
 		}
 		r.routers.Set(routerkey, &vroute[0], defaultCacheExpiration)
 		route = &vroute[0]


### PR DESCRIPTION
Fix issue: #8 
----------------
1.  Deferentiate caller entry between NodeName and ProviderID. Refactory findInstanceByNode (in instance.go), separate it into 2 functions: findInstanceByNodeName and findInstanceByProviderID. The first just return an error,  because once providerID  is supported correctly,  the first method should **never** been called.
2. Route Controller is refactored, using providerID instead of nodeName 