### PR TITLE
 Support LoadBalancer additional tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Thank you for visiting the cloud-provider-alibaba-cloud repository!
 
 
-`cloud-provider-alibaba-cloud` is the external Kubernetes cloud controller manager implementation for AliCloud(Alibaba Cloud). Running `cloud-provider-alibaba-cloud` allows you build your kubernetes clusters leverage on many cloud services on AliCloud. You can read more about Kubernetes cloud controller manager [here](https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/).
+`cloud-provider-alibaba-cloud` is the external Kubernetes cloud controller manager implementation for Alibaba Cloud. Running `cloud-provider-alibaba-cloud` allows you build your kubernetes clusters leverage on many cloud services on Alibaba Cloud. You can read more about Kubernetes cloud controller manager [here](https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/).
 
 ## Development
 

--- a/cloud-controller-manager/loadbalancer.go
+++ b/cloud-controller-manager/loadbalancer.go
@@ -435,11 +435,11 @@ func (s *LoadBalancerClient) UpdateBackendServers(nodes []*v1.Node, lb *slb.Load
 			if len(additions) > MAX_LOADBALANCER_BACKEND {
 				target = additions[0:MAX_LOADBALANCER_BACKEND]
 				additions = additions[MAX_LOADBALANCER_BACKEND:]
-				glog.V(5).Infof("alicloud: batch add backend servers, %s", target)
+				glog.V(5).Infof("alicloud: batch add backend servers, %v", target)
 			} else {
 				target = additions
 				additions = []slb.BackendServerType{}
-				glog.V(5).Infof("alicloud: batch add backend servers, else %s", target)
+				glog.V(5).Infof("alicloud: batch add backend servers, else %v", target)
 			}
 			if _, err := s.c.AddBackendServers(lb.LoadBalancerId, target); err != nil {
 				return err

--- a/cloud-controller-manager/loadbalancer.go
+++ b/cloud-controller-manager/loadbalancer.go
@@ -220,6 +220,35 @@ func (s *LoadBalancerClient) findLoadBalancerByName(name string) (bool, *slb.Loa
 	return err == nil, lb, err
 }
 
+// getLoadBalancerAdditionalTags converts the comma separated list of key-value
+// pairs in the ServiceAnnotationLoadBalancerAdditionalTags annotation and returns
+// it as a map.
+func getLoadBalancerAdditionalTags(annotations map[string]string) map[string]string {
+	additionalTags := make(map[string]string)
+	if additionalTagsList, ok := annotations[ServiceAnnotationLoadBalancerAdditionalTags]; ok {
+		additionalTagsList = strings.TrimSpace(additionalTagsList)
+
+		// Break up list of "Key1=Val,Key2=Val2"
+		tagList := strings.Split(additionalTagsList, ",")
+
+		// Break up "Key=Val"
+		for _, tagSet := range tagList {
+			tag := strings.Split(strings.TrimSpace(tagSet), "=")
+
+			// Accept "Key=val" or "Key=" or just "Key"
+			if len(tag) >= 2 && len(tag[0]) != 0 {
+				// There is a key and a value, so save it
+				additionalTags[tag[0]] = tag[1]
+			} else if len(tag) == 1 && len(tag[0]) != 0 {
+				// Just "Key"
+				additionalTags[tag[0]] = ""
+			}
+		}
+	}
+
+	return additionalTags
+}
+
 func (s *LoadBalancerClient) EnsureLoadBalancer(service *v1.Service, nodes []*v1.Node, vswitchid string) (*slb.LoadBalancerType, error) {
 	glog.V(4).Infof("alicloud: ensure loadbalancer with service details, \n%+v", PrettyJson(service))
 
@@ -256,25 +285,31 @@ func (s *LoadBalancerClient) EnsureLoadBalancer(service *v1.Service, nodes []*v1
 			return nil, err
 		}
 
-		// Tag the loadbalancer.
-		items, err := json.Marshal(
-			[]slb.TagItem{
-				{
-					TagKey:   TAGKEY,
-					TagValue: opts.LoadBalancerName,
-				},
-			},
-		)
+		//deal with loadBalancer tags
+		tags := getLoadBalancerAdditionalTags(getBackwardsCompatibleAnnotation(service.Annotations));
+		loadbalancerName := cloudprovider.GetLoadBalancerName(service)
+		// Add default tags
+		tags[TAGKEY] = loadbalancerName
+
+		tagItemArr := make([]slb.TagItem,0)
+		for key, value := range tags {
+			tagItemArr=append(tagItemArr, slb.TagItem{TagKey: key, TagValue: value})
+			}
+		// TODO if the key size or value size > slb's tag limit or number of tags  >limit(20), tags will insert error.
+
+		tagItems, err := json.Marshal(tagItemArr)
+
 		if err != nil {
 			return nil, err
 		}
 		if err := s.c.AddTags(&slb.AddTagsArgs{
 			RegionId:       opts.RegionId,
 			LoadBalancerID: lbr.LoadBalancerId,
-			Tags:           string(items),
+			Tags:           string(tagItems),
 		}); err != nil {
 			return nil, err
 		}
+
 		origined, err = s.c.DescribeLoadBalancerAttribute(lbr.LoadBalancerId)
 	} else {
 		needUpdate, charge, bandwidth := false, origined.InternetChargeType, origined.Bandwidth

--- a/cloud-controller-manager/loadbalancer.go
+++ b/cloud-controller-manager/loadbalancer.go
@@ -286,15 +286,15 @@ func (s *LoadBalancerClient) EnsureLoadBalancer(service *v1.Service, nodes []*v1
 		}
 
 		//deal with loadBalancer tags
-		tags := getLoadBalancerAdditionalTags(getBackwardsCompatibleAnnotation(service.Annotations));
+		tags := getLoadBalancerAdditionalTags(getBackwardsCompatibleAnnotation(service.Annotations))
 		loadbalancerName := cloudprovider.GetLoadBalancerName(service)
 		// Add default tags
 		tags[TAGKEY] = loadbalancerName
 
-		tagItemArr := make([]slb.TagItem,0)
+		tagItemArr := make([]slb.TagItem, 0)
 		for key, value := range tags {
-			tagItemArr=append(tagItemArr, slb.TagItem{TagKey: key, TagValue: value})
-			}
+			tagItemArr = append(tagItemArr, slb.TagItem{TagKey: key, TagValue: value})
+		}
 		// TODO if the key size or value size > slb's tag limit or number of tags  >limit(20), tags will insert error.
 
 		tagItems, err := json.Marshal(tagItemArr)

--- a/cloud-controller-manager/loadbalancer_test.go
+++ b/cloud-controller-manager/loadbalancer_test.go
@@ -384,3 +384,76 @@ func (c *mockClientSLB) AddTags(args *slb.AddTagsArgs) error {
 	}
 	return nil
 }
+
+
+func TestGetLoadBalancerAdditionalTags(t *testing.T) {
+	tagTests := []struct {
+		Annotations map[string]string
+		Tags        map[string]string
+	}{
+		{
+			Annotations: map[string]string{
+				ServiceAnnotationLoadBalancerAdditionalTags: "",
+			},
+			Tags: map[string]string{
+			},
+		},
+		{
+			Annotations: map[string]string{
+				ServiceAnnotationLoadBalancerAdditionalTags: "Key=Val",
+			},
+			Tags: map[string]string{
+				"Key": "Val",
+			},
+		},
+		{
+			Annotations: map[string]string{
+				ServiceAnnotationLoadBalancerAdditionalTags: "Key1=Val1, Key2=Val2",
+			},
+			Tags: map[string]string{
+				"Key1": "Val1",
+				"Key2": "Val2",
+			},
+		},
+		{
+			Annotations: map[string]string{
+				ServiceAnnotationLoadBalancerAdditionalTags: "Key1=, Key2=Val2",
+				"anotherKey": "anotherValue",
+			},
+			Tags: map[string]string{
+				"Key1": "",
+				"Key2": "Val2",
+			},
+		},
+		{
+			Annotations: map[string]string{
+				"Nothing": "Key1=, Key2=Val2, Key3",
+			},
+			Tags: map[string]string{},
+		},
+		{
+			Annotations: map[string]string{
+				ServiceAnnotationLoadBalancerAdditionalTags: "K=V K1=V2,Key1========, =====, ======Val, =Val, , 234,",
+			},
+			Tags: map[string]string{
+				"K":    "V K1",
+				"Key1": "",
+				"234":  "",
+			},
+		},
+	}
+
+	for _, tagTest := range tagTests {
+		result := getLoadBalancerAdditionalTags(tagTest.Annotations)
+		for k, v := range result {
+			if len(result) != len(tagTest.Tags) {
+				t.Errorf("incorrect expected length: %v != %v", result, tagTest.Tags)
+				continue
+			}
+			if tagTest.Tags[k] != v {
+				t.Errorf("%s != %s", tagTest.Tags[k], v)
+				continue
+			}
+		}
+	}
+}

--- a/cloud-controller-manager/options.go
+++ b/cloud-controller-manager/options.go
@@ -54,6 +54,9 @@ const (
 	ServiceAnnotationLoadBalancerHealthCheckDomain             = ServiceAnnotationLoadBalancerPrefix + "health-check-domain"
 	ServiceAnnotationLoadBalancerHealthCheckHTTPCode           = ServiceAnnotationLoadBalancerPrefix + "health-check-httpcode"
 
+	// For example: "Key1=Val1,Key2=Val2,KeyNoVal1=,KeyNoVal2",same with aws
+	ServiceAnnotationLoadBalancerAdditionalTags				   = ServiceAnnotationLoadBalancerPrefix + "additional-resource-tags"
+
 	ServiceAnnotationLoadBalancerOverrideListener = ServiceAnnotationLoadBalancerPrefix + "force-override-listeners"
 
 	ServiceAnnotationLoadBalancerSpec               = ServiceAnnotationLoadBalancerPrefix + "spec"
@@ -67,14 +70,20 @@ const (
 	MAX_LOADBALANCER_BACKEND = 18
 )
 
+//compatible to old camel annotation
+func getBackwardsCompatibleAnnotation(annotations map[string]string)(map[string]string){
+	newAnnotation := make(map[string]string)
+	for k, v := range annotations {
+		newAnnotation[replaceCamel(k)] = v
+	}
+	return newAnnotation;
+}
+
 // defaulted is the parameters which set by programe.
 // request represent user defined parameters.
 func ExtractAnnotationRequest(service *v1.Service) (*AnnotationRequest, *AnnotationRequest) {
 	defaulted, request := &AnnotationRequest{}, &AnnotationRequest{}
-	annotation := make(map[string]string)
-	for k, v := range service.Annotations {
-		annotation[replaceCamel(k)] = v
-	}
+	annotation := getBackwardsCompatibleAnnotation(service.Annotations);
 	bandwidth, ok := annotation[ServiceAnnotationLoadBalancerBandwidth]
 	if ok {
 		if i, err := strconv.Atoi(bandwidth); err == nil {

--- a/cloud-controller-manager/routes.go
+++ b/cloud-controller-manager/routes.go
@@ -85,7 +85,7 @@ func (r *RoutesClient) findRouter(region common.Region, vpcid string) (*ecs.VRou
 		}
 		if len(vroute) <= 0 {
 			return nil, fmt.Errorf("can not find VRouter metadata "+
-				"by instance. region=%s,vpcid=%s, error=[no VRouter found by specified id]", region, vpc)
+				"by instance. region=%s,vpcid=%v, error=[no VRouter found by specified id]", region, vpc)
 		}
 		r.routers.Set(routerkey, &vroute[0], defaultCacheExpiration)
 		route = &vroute[0]

--- a/hack/metaserver-deploy.yaml
+++ b/hack/metaserver-deploy.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1 # for versions before 1.8.0 use apps/v1beta1
+kind: Deployment
+metadata:
+  name: metaserver
+  labels:
+    app: metaserver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: metaserver
+  template:
+    metadata:
+      labels:
+        app: metaserver
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+      containers:
+        - name: nginx-net
+          image: registry.cn-hangzhou.aliyuncs.com/spacexnice/nginx-net:latest

--- a/hack/metaserver-svc.yaml
+++ b/hack/metaserver-svc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: metaserver
+  name: metaserver
+  namespace: default
+spec:
+  ports:
+    - nodePort: 31977
+      port: 80
+      protocol: TCP
+      targetPort: 80
+  selector:
+    app: metaserver
+  type: NodePort

--- a/hack/setup.sh
+++ b/hack/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e -x
 if [ -z $APISERVER_IP ];then
-	APISERVER_IP=120.55.105.57
+	APISERVER_IP=47.110.118.25
 fi
 ### rename your cloud-controller-manager image.
 kubectl get ds -n kube-system cloud-controller-manager -o yaml |grep image:|awk -F "image: " '{print $2}'|xargs -I '{}' kubectl set image ds/cloud-controller-manager -n kube-system cloud-controller-manager={}-bak
@@ -15,25 +15,8 @@ setup_localproxy()
 	echo "1. check to see whether metaserver proxy is running..."
 	cnt=$(kubectl get deploy 2>&1|grep metaserver|wc -l)
 	if [[ "$cnt" == *"0"* ]];then
-	    kubectl run  metaserver --image=registry.cn-hangzhou.aliyuncs.com/spacexnice/nginx-net:latest
-	    cat <<EOF | kubectl apply -f -
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    run: metaserver
-  name: metaserver
-  namespace: default
-spec:
-  ports:
-  - nodePort: 31977
-    port: 80
-    protocol: TCP
-    targetPort: 80
-  selector:
-    run: metaserver
-  type: NodePort
-EOF
+	    kubectl apply -f hack/metaserver-deploy.yaml
+	    kubectl apply -f hack/metaserver-svc.yaml
 	    echo "    run new metaserver successfully."
 	fi
 


### PR DESCRIPTION
**Why is this needed:**
need to tag different SLB created by cloud provider


**What would you like to be added:**

add new annotation 
key=service.beta.kubernetes.io/alicloud-loadbalancer-additional-resource-tags
value=Key1=Val1,Key2=Val2,KeyNoVal1=,KeyNoVal2

caution:
1.only effective on create
2.not deal with tag's kv length limit
3.not deal with tag number quota


/kind feature
/cc @aoxn 
