### PR TITLE
 Support configure private zone with loadbalancer

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,328 +2,420 @@
 
 
 [[projects]]
+  digest = "1:8e47871087b94913898333f37af26732faaab30cdb41571136cf7aec9921dae7"
   name = "github.com/PuerkitoBio/purell"
   packages = ["."]
+  pruneopts = ""
   revision = "0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:331a419049c2be691e5ba1d24342fc77c7e767a80c666a18fd8a9f7b82419c1c"
   name = "github.com/PuerkitoBio/urlesc"
   packages = ["."]
+  pruneopts = ""
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
   branch = "master"
+  digest = "1:c0bec5f9b98d0bc872ff5e834fac186b807b656683bd29cb82fb207a1513fabb"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
+  pruneopts = ""
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
+  digest = "1:56c130d885a4aacae1dd9c7b71cfe39912c7ebc1ff7d2b46083c8812996dc43b"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = ""
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:95a498d57551a54064803f3d4c0a0099b33929ecdc78f465ce42626c51e62d68"
   name = "github.com/denverdino/aliyungo"
   packages = [
     "common",
     "ecs",
     "metadata",
+    "pvtz",
     "slb",
-    "util"
+    "util",
   ]
-  revision = "7d118cb1616f4fd9821585674887e72d44c22d86"
+  pruneopts = ""
+  revision = "e961d750c2140677549c8668abd0b8694e818efc"
 
 [[projects]]
+  digest = "1:6098222470fe0172157ce9bbef5d2200df4edde17ee649c5d6e48330e4afa4c6"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
+  pruneopts = ""
   revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
   version = "v3.2.0"
 
 [[projects]]
+  digest = "1:45d8d5e216f60b88e3e196f1b31130d683fa5e8563780657ed3387fe8739b5cc"
   name = "github.com/docker/distribution"
   packages = [
     "digestset",
-    "reference"
+    "reference",
   ]
+  pruneopts = ""
   revision = "545102ea07aa9796f189d82f606b7c27d7aa3ed3"
 
 [[projects]]
+  digest = "1:8a34d7a37b8f07239487752e14a5faafcbbc718fc385ad429a2c4ac6f27a207f"
   name = "github.com/emicklei/go-restful"
   packages = [
     ".",
-    "log"
+    "log",
   ]
+  pruneopts = ""
   revision = "3eb9738c1697594ea6e71a7156a9bb32ed216cf0"
   version = "v2.8.0"
 
 [[projects]]
+  digest = "1:b13707423743d41665fd23f0c36b2f37bb49c30e94adb813319c44188a51ba22"
   name = "github.com/ghodss/yaml"
   packages = ["."]
+  pruneopts = ""
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:e116a4866bffeec941056a1fcfd37e520fad1ee60e4e3579719f19a43c392e10"
   name = "github.com/go-openapi/jsonpointer"
   packages = ["."]
+  pruneopts = ""
   revision = "3a0015ad55fa9873f41605d3e8f28cd279c32ab2"
 
 [[projects]]
   branch = "master"
+  digest = "1:3830527ef0f4f9b268d9286661c0f52f9115f8aefd9f45ee7352516f93489ac9"
   name = "github.com/go-openapi/jsonreference"
   packages = ["."]
+  pruneopts = ""
   revision = "3fb327e6747da3043567ee86abd02bb6376b6be2"
 
 [[projects]]
   branch = "master"
+  digest = "1:6caee195f5da296689270037c5a25c0bc3cc6e54ae5a356e395aa8946356dbc9"
   name = "github.com/go-openapi/spec"
   packages = ["."]
+  pruneopts = ""
   revision = "bce47c9386f9ecd6b86f450478a80103c3fe1402"
 
 [[projects]]
   branch = "master"
+  digest = "1:22da48dbccb0539f511efbbbdeba68081866892234e57a9d7c7f9848168ae30c"
   name = "github.com/go-openapi/swag"
   packages = ["."]
+  pruneopts = ""
   revision = "2b0bd4f193d011c203529df626a65d63cb8a79e8"
 
 [[projects]]
+  digest = "1:0a3f6a0c68ab8f3d455f8892295503b179e571b7fefe47cc6c556405d1f83411"
   name = "github.com/gogo/protobuf"
   packages = [
     "proto",
-    "sortkeys"
+    "sortkeys",
   ]
+  pruneopts = ""
   revision = "1adfc126b41513cc696b209667c8656ea7aac67c"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:107b233e45174dbab5b1324201d092ea9448e58243ab9f039e4c0f332e121e3a"
   name = "github.com/golang/glog"
   packages = ["."]
+  pruneopts = ""
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
   branch = "master"
+  digest = "1:1d8a57fce1f68298ce54967c0752a2ab54bf55dff261d245b8f3440a217700cb"
   name = "github.com/golang/groupcache"
   packages = ["lru"]
+  pruneopts = ""
   revision = "24b0969c4cb722950103eed87108c8d291a8df00"
 
 [[projects]]
+  digest = "1:f958a1c137db276e52f0b50efee41a1a389dcdded59a69711f3e872757dab34b"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp"
+    "ptypes/timestamp",
   ]
+  pruneopts = ""
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:be28c0531a755f2178acf1e327e6f5a8a3968feb5f2567cdc968064253141751"
   name = "github.com/google/btree"
   packages = ["."]
+  pruneopts = ""
   revision = "e89373fe6b4a7413d7acd6da1725b83ef713e6e4"
 
 [[projects]]
   branch = "master"
+  digest = "1:754f77e9c839b24778a4b64422236d38515301d2baeb63113aa3edc42e6af692"
   name = "github.com/google/gofuzz"
   packages = ["."]
+  pruneopts = ""
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 
 [[projects]]
+  digest = "1:16b2837c8b3cf045fa2cdc82af0cf78b19582701394484ae76b2c3bc3c99ad73"
   name = "github.com/googleapis/gnostic"
   packages = [
     "OpenAPIv2",
     "compiler",
-    "extensions"
+    "extensions",
   ]
+  pruneopts = ""
   revision = "7c663266750e7d82587642f65e60bc4083f1f84e"
   version = "v0.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:009a1928b8c096338b68b5822d838a72b4d8520715c1463614476359f3282ec8"
   name = "github.com/gregjones/httpcache"
   packages = [
     ".",
-    "diskcache"
+    "diskcache",
   ]
+  pruneopts = ""
   revision = "9cad4c3443a7200dd6400aef47183728de563a38"
 
 [[projects]]
   branch = "master"
+  digest = "1:9c776d7d9c54b7ed89f119e449983c3f24c0023e75001d6092442412ebca6b94"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
-    "simplelru"
+    "simplelru",
   ]
+  pruneopts = ""
   revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
 
 [[projects]]
   branch = "master"
+  digest = "1:f81c8d7354cc0c6340f2f7a48724ee6c2b3db3e918ecd441c985b4d2d97dd3e7"
   name = "github.com/howeyc/gopass"
   packages = ["."]
+  pruneopts = ""
   revision = "bf9dde6d0d2c004a008c27aaee91170c786f6db8"
 
 [[projects]]
+  digest = "1:302c6eb8e669c997bec516a138b8fc496018faa1ece4c13e445a2749fbe079bb"
   name = "github.com/imdario/mergo"
   packages = ["."]
+  pruneopts = ""
   revision = "9316a62528ac99aaecb4e47eadd6dc8aa6533d58"
   version = "v0.3.5"
 
 [[projects]]
+  digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
+  pruneopts = ""
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
 
 [[projects]]
+  digest = "1:53ac4e911e12dde0ab68655e2006449d207a5a681f084974da2b06e5dbeaca72"
   name = "github.com/json-iterator/go"
   packages = ["."]
+  pruneopts = ""
   revision = "ab8a2e0c74be9d3be70b3184d9acc634935ded82"
   version = "1.1.4"
 
 [[projects]]
+  digest = "1:d26c006cbf54ca5c040463d5678013169e2bd91fb62c2f960ae283a1723d4278"
   name = "github.com/juju/ratelimit"
   packages = ["."]
+  pruneopts = ""
   revision = "59fac5042749a5afb9af70e813da1dd5474f0167"
   version = "1.0.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:d9e483f4b9e306facf126bd90b02d512bd22ea4471e1568867e32221a8abbb16"
   name = "github.com/mailru/easyjson"
   packages = [
     "buffer",
     "jlexer",
-    "jwriter"
+    "jwriter",
   ]
+  pruneopts = ""
   revision = "3fdea8d05856a0c8df22ed4bc71b3219245e4485"
 
 [[projects]]
+  digest = "1:63722a4b1e1717be7b98fc686e0b30d5e7f734b9e93d7dee86293b6deab7ea28"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
+  pruneopts = ""
   revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:0c0ff2a89c1bb0d01887e1dac043ad7efbf3ec77482ef058ac423d13497e16fd"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
+  pruneopts = ""
   revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
   version = "1.0.3"
 
 [[projects]]
+  digest = "1:e32bdbdb7c377a07a9a46378290059822efdce5c8d96fe71940d87cb4f918855"
   name = "github.com/modern-go/reflect2"
   packages = ["."]
+  pruneopts = ""
   revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
   version = "1.0.1"
 
 [[projects]]
+  digest = "1:5d9b668b0b4581a978f07e7d2e3314af18eb27b3fb5d19b70185b7c575723d11"
   name = "github.com/opencontainers/go-digest"
   packages = ["."]
+  pruneopts = ""
   revision = "279bed98673dd5bef374d3b6e4b09e2af76183bf"
   version = "v1.0.0-rc1"
 
 [[projects]]
   branch = "master"
+  digest = "1:9008eeeeac74cd2a5ae13716d386ced81a12bf8669ee73b15f45824397ce0f03"
   name = "github.com/patrickmn/go-cache"
   packages = ["."]
+  pruneopts = ""
   revision = "9f6ff22cfff829561052f5886ec80a2ac148b4eb"
 
 [[projects]]
   branch = "master"
+  digest = "1:c24598ffeadd2762552269271b3b1510df2d83ee6696c1e543a0ff653af494bc"
   name = "github.com/petar/GoLLRB"
   packages = ["llrb"]
+  pruneopts = ""
   revision = "53be0d36a84c2a886ca057d34b6aa4468df9ccb4"
 
 [[projects]]
+  digest = "1:b46305723171710475f2dd37547edd57b67b9de9f2a6267cafdd98331fd6897f"
   name = "github.com/peterbourgon/diskv"
   packages = ["."]
+  pruneopts = ""
   revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
   version = "v2.0.1"
 
 [[projects]]
+  digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = ""
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
+  digest = "1:4142d94383572e74b42352273652c62afec5b23f325222ed09198f46009022d1"
   name = "github.com/prometheus/client_golang"
   packages = ["prometheus"]
+  pruneopts = ""
   revision = "c5b7fccd204277076155f10851dad72b76a49317"
   version = "v0.8.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:60aca47f4eeeb972f1b9da7e7db51dee15ff6c59f7b401c1588b8e6771ba15ef"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
+  pruneopts = ""
   revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
 
 [[projects]]
   branch = "master"
+  digest = "1:bfbc121ef802d245ef67421cff206615357d9202337a3d492b8f668906b485a8"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
     "internal/bitbucket.org/ww/goautoneg",
-    "model"
+    "model",
   ]
+  pruneopts = ""
   revision = "7600349dcfe1abd18d72d3a1770870d9800a7801"
 
 [[projects]]
   branch = "master"
+  digest = "1:b694a6bdecdace488f507cff872b30f6f490fdaf988abd74d87ea56406b23b6e"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
     "internal/util",
     "nfs",
-    "xfs"
+    "xfs",
   ]
+  pruneopts = ""
   revision = "ae68e2d4c00fed4943b5f6698d504a5fe083da8a"
 
 [[projects]]
+  digest = "1:a1403cc8a94b8d7956ee5e9694badef0e7b051af289caad1cf668331e3ffa4f6"
   name = "github.com/spf13/cobra"
   packages = ["."]
+  pruneopts = ""
   revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
   version = "v0.0.3"
 
 [[projects]]
+  digest = "1:8e243c568f36b09031ec18dff5f7d2769dcf5ca4d624ea511c8e3197dc3d352d"
   name = "github.com/spf13/pflag"
   packages = ["."]
+  pruneopts = ""
   revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
   version = "v1.0.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:6ef14be530be39b6b9d75d54ce1d546ae9231e652d9e3eef198cbb19ce8ed3e7"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
+  pruneopts = ""
   revision = "a49355c7e3f8fe157a85be2f77e6e269a0f89602"
 
 [[projects]]
   branch = "master"
+  digest = "1:7f964bcb1ea681ed36b80aeb72653eaa349372074918363615ce935faeeb54fb"
   name = "golang.org/x/net"
   packages = [
     "context",
     "http/httpguts",
     "http2",
     "http2/hpack",
-    "idna"
+    "idna",
   ]
+  pruneopts = ""
   revision = "039a4258aec0ad3c79b905677cceeab13b296a77"
 
 [[projects]]
   branch = "master"
+  digest = "1:19f072f12708aaafef9064b49432953e3f813a98fcb356b30831cf2b0f5272b3"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows"
+    "windows",
   ]
+  pruneopts = ""
   revision = "1b2967e3c290b7c545b3db0deeda16e9be4f98a2"
 
 [[projects]]
+  digest = "1:5acd3512b047305d49e8763eef7ba423901e85d5dd2fd1e71778a0ea8de10bd4"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -340,25 +432,31 @@
     "unicode/cldr",
     "unicode/norm",
     "unicode/rangetable",
-    "width"
+    "width",
   ]
+  pruneopts = ""
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
+  digest = "1:75fb3fcfc73a8c723efde7777b40e8e8ff9babf30d8c56160d01beffea8a95a6"
   name = "gopkg.in/inf.v0"
   packages = ["."]
+  pruneopts = ""
   revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
   version = "v0.9.1"
 
 [[projects]]
+  digest = "1:f0620375dd1f6251d9973b5f2596228cc8042e887cd7f827e4220bc1ce8c30e2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = ""
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [[projects]]
   branch = "release-1.9"
+  digest = "1:8a154464dc1ea7a9c16a34583693b194235218c08e4ff668eee49a3746bcc0a5"
   name = "k8s.io/api"
   packages = [
     "admissionregistration/v1alpha1",
@@ -388,18 +486,22 @@
     "settings/v1alpha1",
     "storage/v1",
     "storage/v1alpha1",
-    "storage/v1beta1"
+    "storage/v1beta1",
   ]
+  pruneopts = ""
   revision = "9273ee02527c608cecc74969b3e489f5dba686da"
 
 [[projects]]
   branch = "master"
+  digest = "1:3f17b5076dfd753cc5f4f21e4d569ed2e94b3a4ff3965874582939afb85ab6f1"
   name = "k8s.io/apiextensions-apiserver"
   packages = ["pkg/features"]
+  pruneopts = ""
   revision = "29a2b5e2b48eeaba42bba7d57afe9414f1e9e40a"
 
 [[projects]]
   branch = "release-1.9"
+  digest = "1:5ab6164cabb8b939ae6d7a01d6e534c5e88eaf3c4f5040f803ad22591c95c639"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/equality",
@@ -448,12 +550,14 @@
     "pkg/version",
     "pkg/watch",
     "third_party/forked/golang/json",
-    "third_party/forked/golang/reflect"
+    "third_party/forked/golang/reflect",
   ]
+  pruneopts = ""
   revision = "fb40df2b502912cbe3a93aa61c2b2487f39cb42f"
 
 [[projects]]
   branch = "release-1.9"
+  digest = "1:0649740cfbe0d1f8d9d529234d974efd57dcffa2d6179aa9215cf7103ef0dc31"
   name = "k8s.io/apiserver"
   packages = [
     "pkg/authentication/authenticator",
@@ -463,12 +567,14 @@
     "pkg/server/healthz",
     "pkg/util/feature",
     "pkg/util/flag",
-    "pkg/util/logs"
+    "pkg/util/logs",
   ]
+  pruneopts = ""
   revision = "0c27ac7eec3e47fa7637c9dba4ecf70494bbc28a"
 
 [[projects]]
   branch = "release-6.0"
+  digest = "1:1f4b732b2aceee905b23ec988196336a03f0cb370c0c24923de2d2360d103fb9"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -588,21 +694,25 @@
     "util/homedir",
     "util/integer",
     "util/retry",
-    "util/workqueue"
+    "util/workqueue",
   ]
+  pruneopts = ""
   revision = "e2680bfa771859c129bc5c8413fdb565af2b3dcd"
 
 [[projects]]
   branch = "master"
+  digest = "1:a2f78b8fd86be41f2aa77404245aed4f4f410ac3aabc5f3bd9bd1fcc09076c53"
   name = "k8s.io/kube-openapi"
   packages = [
     "pkg/common",
-    "pkg/util/proto"
+    "pkg/util/proto",
   ]
+  pruneopts = ""
   revision = "0cf8f7e6ed1d2e3d47d02e3b6e559369af24d803"
 
 [[projects]]
   branch = "release-1.9"
+  digest = "1:94e07dce52346ac8e94b235f56601d2120f8292090280452d7a434b69df74c04"
   name = "k8s.io/kubernetes"
   packages = [
     "pkg/api/legacyscheme",
@@ -651,13 +761,71 @@
     "plugin/pkg/scheduler/api",
     "plugin/pkg/scheduler/schedulercache",
     "plugin/pkg/scheduler/util",
-    "staging/src/k8s.io/apimachinery/pkg/util/json"
+    "staging/src/k8s.io/apimachinery/pkg/util/json",
   ]
+  pruneopts = ""
   revision = "3b33517c1ea2657e5b6be64b87725790a8f29a43"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6a73176836d8503c9d1864308fc9e7e9e23fcb5c3d175d8cf0b54aa7a234d1de"
+  input-imports = [
+    "github.com/denverdino/aliyungo/common",
+    "github.com/denverdino/aliyungo/ecs",
+    "github.com/denverdino/aliyungo/metadata",
+    "github.com/denverdino/aliyungo/pvtz",
+    "github.com/denverdino/aliyungo/slb",
+    "github.com/denverdino/aliyungo/util",
+    "github.com/golang/glog",
+    "github.com/patrickmn/go-cache",
+    "github.com/pkg/errors",
+    "github.com/prometheus/client_golang/prometheus",
+    "github.com/spf13/cobra",
+    "github.com/spf13/pflag",
+    "k8s.io/api/core/v1",
+    "k8s.io/apimachinery/pkg/api/errors",
+    "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/labels",
+    "k8s.io/apimachinery/pkg/types",
+    "k8s.io/apimachinery/pkg/util/errors",
+    "k8s.io/apimachinery/pkg/util/intstr",
+    "k8s.io/apimachinery/pkg/util/runtime",
+    "k8s.io/apimachinery/pkg/util/wait",
+    "k8s.io/apiserver/pkg/server/healthz",
+    "k8s.io/apiserver/pkg/util/feature",
+    "k8s.io/apiserver/pkg/util/flag",
+    "k8s.io/apiserver/pkg/util/logs",
+    "k8s.io/client-go/informers",
+    "k8s.io/client-go/informers/core/v1",
+    "k8s.io/client-go/kubernetes",
+    "k8s.io/client-go/kubernetes/scheme",
+    "k8s.io/client-go/kubernetes/typed/core/v1",
+    "k8s.io/client-go/listers/core/v1",
+    "k8s.io/client-go/rest",
+    "k8s.io/client-go/tools/cache",
+    "k8s.io/client-go/tools/clientcmd",
+    "k8s.io/client-go/tools/leaderelection",
+    "k8s.io/client-go/tools/leaderelection/resourcelock",
+    "k8s.io/client-go/tools/record",
+    "k8s.io/client-go/util/workqueue",
+    "k8s.io/kubernetes/pkg/api/legacyscheme",
+    "k8s.io/kubernetes/pkg/api/v1/node",
+    "k8s.io/kubernetes/pkg/apis/componentconfig",
+    "k8s.io/kubernetes/pkg/apis/core/v1/helper",
+    "k8s.io/kubernetes/pkg/client/leaderelectionconfig",
+    "k8s.io/kubernetes/pkg/client/metrics/prometheus",
+    "k8s.io/kubernetes/pkg/cloudprovider",
+    "k8s.io/kubernetes/pkg/controller",
+    "k8s.io/kubernetes/pkg/controller/cloud",
+    "k8s.io/kubernetes/pkg/features",
+    "k8s.io/kubernetes/pkg/master/ports",
+    "k8s.io/kubernetes/pkg/util/configz",
+    "k8s.io/kubernetes/pkg/util/metrics",
+    "k8s.io/kubernetes/pkg/util/node",
+    "k8s.io/kubernetes/pkg/version",
+    "k8s.io/kubernetes/pkg/version/prometheus",
+    "k8s.io/kubernetes/pkg/version/verflag",
+    "k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/json",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cloud-controller-manager/alicloud.go
+++ b/cloud-controller-manager/alicloud.go
@@ -161,8 +161,16 @@ func (c *Cloud) GetLoadBalancer(clusterName string, service *v1.Service) (status
 		return nil, exists, err
 	}
 
+	zone, record, exists, err := c.climgr.PrivateZones().findExactRecordByService(service, lb.Address)
+	if err != nil || !exists {
+		return nil, exists, err
+	}
+
 	return &v1.LoadBalancerStatus{
-		Ingress: []v1.LoadBalancerIngress{{IP: lb.Address}}}, true, nil
+		Ingress: []v1.LoadBalancerIngress{{
+			IP:       lb.Address,
+			Hostname: getHostName(zone, record),
+		}}}, true, nil
 }
 
 // EnsureLoadBalancer creates a new load balancer 'name', or updates the existing one. Returns the status of the balancer
@@ -215,10 +223,17 @@ func (c *Cloud) EnsureLoadBalancer(clusterName string, service *v1.Service, node
 	if err != nil {
 		return nil, err
 	}
+
+	pz, pzr, err := c.climgr.PrivateZones().EnsurePrivateZoneRecord(service, lb.Address)
+	if err != nil {
+		return nil, err
+	}
+
 	return &v1.LoadBalancerStatus{
 		Ingress: []v1.LoadBalancerIngress{
 			{
-				IP: lb.Address,
+				IP:       lb.Address,
+				Hostname: getHostName(pz, pzr),
 			},
 		},
 	}, nil
@@ -249,6 +264,14 @@ func (c *Cloud) UpdateLoadBalancer(clusterName string, service *v1.Service, node
 func (c *Cloud) EnsureLoadBalancerDeleted(clusterName string, service *v1.Service) error {
 	glog.V(2).Infof("Alicloud.EnsureLoadBalancerDeleted(%v, %v, %v, %v, %v, %v)",
 		clusterName, service.Namespace, service.Name, c.region, service.Spec.LoadBalancerIP, service.Spec.Ports)
+
+	if len(service.Status.LoadBalancer.Ingress) > 0 {
+		err := c.climgr.PrivateZones().EnsurePrivateZoneRecordDeleted(service, service.Status.LoadBalancer.Ingress[0].IP)
+		if err != nil {
+			return err
+		}
+	}
+
 	return c.climgr.LoadBalancers().EnsureLoadBalanceDeleted(service)
 }
 

--- a/cloud-controller-manager/loadbalancer.go
+++ b/cloud-controller-manager/loadbalancer.go
@@ -70,6 +70,11 @@ type AnnotationRequest struct {
 	AddressIPVersion   slb.AddressIPVersionType
 
 	OverrideListeners string
+
+	PrivateZoneName       string
+	PrivateZoneId         string
+	PrivateZoneRecordName string
+	PrivateZoneRecordTTL  int
 }
 
 const TAGKEY = "kubernetes.do.not.delete"
@@ -484,7 +489,6 @@ func hasPort(svc *v1.Service, port int32) bool {
 }
 
 func (s *LoadBalancerClient) EnsureLoadBalanceDeleted(service *v1.Service) error {
-
 	// need to save the resource version when deleted event
 	err := keepResourceVesion(service)
 	if err != nil {

--- a/cloud-controller-manager/options.go
+++ b/cloud-controller-manager/options.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	ServiceAnnotationLoadBalancerPrefix = "service.beta.kubernetes.io/alicloud-loadbalancer-"
-	ServiceAnnotationPrivateZonePrefix  = "service.beta.kubernetes.io/alicloud-private-zone-"
+	ServiceAnnotationPrivateZonePrefix  = "service.beta.kubernetes.io/alibaba-cloud-private-zone-"
 
 	ServiceAnnotationLoadBalancerProtocolPort                  = ServiceAnnotationLoadBalancerPrefix + "protocol-port"
 	ServiceAnnotationLoadBalancerAddressType                   = ServiceAnnotationLoadBalancerPrefix + "address-type"

--- a/cloud-controller-manager/options.go
+++ b/cloud-controller-manager/options.go
@@ -30,8 +30,11 @@ import (
 )
 
 const (
-	ServiceAnnotationLoadBalancerPrefix = "service.beta.kubernetes.io/alicloud-loadbalancer-"
-	ServiceAnnotationPrivateZonePrefix  = "service.beta.kubernetes.io/alibaba-cloud-private-zone-"
+	ServiceAnnotationPrefix       = "service.beta.kubernetes.io/alibaba-cloud-"
+	ServiceAnnotationLegacyPrefix = "service.beta.kubernetes.io/alicloud-"
+
+	ServiceAnnotationLoadBalancerPrefix = ServiceAnnotationPrefix + "loadbalancer-"
+	ServiceAnnotationPrivateZonePrefix  = ServiceAnnotationPrefix + "private-zone-"
 
 	ServiceAnnotationLoadBalancerProtocolPort                  = ServiceAnnotationLoadBalancerPrefix + "protocol-port"
 	ServiceAnnotationLoadBalancerAddressType                   = ServiceAnnotationLoadBalancerPrefix + "address-type"
@@ -81,7 +84,7 @@ const (
 func getBackwardsCompatibleAnnotation(annotations map[string]string) map[string]string {
 	newAnnotation := make(map[string]string)
 	for k, v := range annotations {
-		newAnnotation[replaceCamel(k)] = v
+		newAnnotation[replaceCamel(normalizePrefix(k))] = v
 	}
 	return newAnnotation
 }
@@ -435,6 +438,16 @@ func serviceAnnotation(service *v1.Service, annotate string) string {
 		}
 	}
 	return ""
+}
+
+// Change the legacy prefix 'alicloud' to 'alibaba-cloud'
+func normalizePrefix(str string) string {
+	if !strings.HasPrefix(str, ServiceAnnotationLegacyPrefix) {
+		// If it is not start with ServiceAnnotationLegacyPrefix, just skip
+		return str
+	}
+
+	return ServiceAnnotationPrefix + str[len(ServiceAnnotationLegacyPrefix):]
 }
 
 func replaceCamel(str string) string {

--- a/cloud-controller-manager/privatezone.go
+++ b/cloud-controller-manager/privatezone.go
@@ -1,0 +1,306 @@
+package alicloud
+
+import (
+	"fmt"
+	"github.com/denverdino/aliyungo/pvtz"
+	"github.com/golang/glog"
+	"k8s.io/api/core/v1"
+)
+
+const DEFAULT_LANG = "en"
+
+type ClientPVTZSDK interface {
+	DescribeZones(args *pvtz.DescribeZonesArgs) (zones []pvtz.ZoneType, err error)
+	AddZone(args *pvtz.AddZoneArgs) (response *pvtz.AddZoneResponse, err error)
+	DeleteZone(args *pvtz.DeleteZoneArgs) (err error)
+	CheckZoneName(args *pvtz.CheckZoneNameArgs) (bool, error)
+	UpdateZoneRemark(args *pvtz.UpdateZoneRemarkArgs) error
+	DescribeZoneInfo(args *pvtz.DescribeZoneInfoArgs) (response *pvtz.DescribeZoneInfoResponse, err error)
+	BindZoneVpc(args *pvtz.BindZoneVpcArgs) (err error)
+	DescribeRegions() (regions []pvtz.RegionType, err error)
+	DescribeZoneRecords(args *pvtz.DescribeZoneRecordsArgs) (records []pvtz.ZoneRecordType, err error)
+	DescribeZoneRecordsByRR(zoneId string, rr string) (records []pvtz.ZoneRecordType, err error)
+	DeleteZoneRecordsByRR(zoneId string, rr string) error
+	AddZoneRecord(args *pvtz.AddZoneRecordArgs) (response *pvtz.AddZoneRecordResponse, err error)
+	UpdateZoneRecord(args *pvtz.UpdateZoneRecordArgs) (err error)
+	DeleteZoneRecord(args *pvtz.DeleteZoneRecordArgs) (err error)
+	SetZoneRecordStatus(args *pvtz.SetZoneRecordStatusArgs) (err error)
+}
+
+type PrivateZoneClient struct {
+	c ClientPVTZSDK
+	// known service resource version
+}
+
+func (s *PrivateZoneClient) findPrivateZone(service *v1.Service) (bool, *pvtz.DescribeZoneInfoResponse, error) {
+	def, _ := ExtractAnnotationRequest(service)
+
+	// User assigned private zone id go first.
+	if def.PrivateZoneId != "" {
+		return s.findPrivateZoneById(def.PrivateZoneId)
+	}
+
+	// if not, find by private zone name
+	if def.PrivateZoneName != "" {
+		return s.findPrivateZoneByName(def.PrivateZoneName)
+	}
+
+	return false, nil, nil
+}
+
+func (s *PrivateZoneClient) findPrivateZoneById(id string) (bool, *pvtz.DescribeZoneInfoResponse, error) {
+	zone, err := s.c.DescribeZoneInfo(
+		&pvtz.DescribeZoneInfoArgs{
+			Lang:   DEFAULT_LANG,
+			ZoneId: id,
+		},
+	)
+	if zone == nil {
+		return false, nil, err
+	}
+
+	return true, zone, nil
+}
+
+func (s *PrivateZoneClient) findPrivateZoneByName(name string) (bool, *pvtz.DescribeZoneInfoResponse, error) {
+	zones, err := s.c.DescribeZones(
+		&pvtz.DescribeZonesArgs{
+			Lang:    DEFAULT_LANG,
+			Keyword: name,
+		},
+	)
+	if err != nil {
+		return false, nil, err
+	}
+
+	if zones == nil || len(zones) == 0 {
+		return false, nil, nil
+	}
+
+	var selectedZoneId string
+
+	// recommend user to use the private zone that name can perfectly match to configured name
+	// if we found one can't match to configured name perfectly, give user a warning
+	if len(zones) > 1 {
+		for _, zone := range zones {
+			if zone.ZoneName == name {
+				selectedZoneId = zone.ZoneId
+				break
+			}
+		}
+
+		if selectedZoneId == "" {
+			glog.Warningf("alicloud: multiple private zone returned with name [%s], "+
+				"and we can't find one which matches to name perfectly,"+
+				"using the first one with ID=%s", name, zones[0].ZoneId)
+			selectedZoneId = zones[0].ZoneId
+		}
+	} else {
+		if zones[0].ZoneName != name {
+			glog.Warningf("alicloud: just one private zone returned with name [%s], "+
+				"but this private zone can't match to name perfectly,"+
+				"found private zone ID=%s", name, zones[0].ZoneId)
+		}
+		selectedZoneId = zones[0].ZoneId
+	}
+
+	return s.findPrivateZoneById(zones[0].ZoneId)
+}
+
+func (s *PrivateZoneClient) findRecordByRr(zone *pvtz.DescribeZoneInfoResponse, rr string) (*pvtz.ZoneRecordType, error) {
+	records, err := s.c.DescribeZoneRecordsByRR(zone.ZoneId, rr)
+	if err != nil {
+		return nil, err
+	}
+
+	switch len(records) {
+	case 0:
+		return nil, nil
+	case 1:
+		return &records[0], nil
+	default:
+		return nil, fmt.Errorf("alicloud: multiple private zone record returned with rr [%s]", rr)
+	}
+}
+
+func (s *PrivateZoneClient) findRecordByService(service *v1.Service) (*pvtz.DescribeZoneInfoResponse, *pvtz.ZoneRecordType, error) {
+	_, request := ExtractAnnotationRequest(service)
+
+	if request.PrivateZoneRecordName == "" {
+		return nil, nil, nil
+	}
+
+	exists, zone, err := s.findPrivateZone(service)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if !exists {
+		return nil, nil, err
+	}
+
+	record, err := s.findRecordByRr(zone, request.PrivateZoneRecordName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if record == nil {
+		return zone, nil, nil
+	}
+
+	return zone, record, nil
+}
+
+func (s *PrivateZoneClient) findExactRecordByService(service *v1.Service, ip string) (*pvtz.DescribeZoneInfoResponse, *pvtz.ZoneRecordType, bool, error) {
+	zone, record, err := s.findRecordByService(service)
+	if err != nil {
+		return nil, nil, false, err
+	}
+
+	// check the ip is matched with ip address, if not it may be user managed
+	if record.Type != "A" || record.Value != ip {
+		return zone, record, false, nil
+	}
+
+	return zone, record, true, nil
+}
+
+func (s *PrivateZoneClient) updateRecordCache(service *v1.Service, zone *pvtz.DescribeZoneInfoResponse, record *pvtz.ZoneRecordType, err error) (*pvtz.DescribeZoneInfoResponse, *pvtz.ZoneRecordType, error) {
+	if err != nil {
+		return zone, record, err
+	}
+
+	kv := GetPrivateZoneRecordCache()
+
+	var recordId int64 = -1
+	previousId, found := kv.get(string(service.GetUID()))
+
+	if record != nil {
+		recordId = record.RecordId
+	}
+
+	// we will delete record which we created before
+	if found && previousId != recordId {
+		_ = s.c.DeleteZoneRecord(&pvtz.DeleteZoneRecordArgs{
+			RecordId: previousId,
+			Lang:     DEFAULT_LANG,
+		})
+	}
+
+	// update new record id to cache or delete cache
+	if record != nil {
+		kv.set(string(service.GetUID()), recordId)
+	} else {
+		kv.remove(string(service.GetUID()))
+	}
+
+	return zone, record, err
+}
+
+func (s *PrivateZoneClient) EnsurePrivateZoneRecord(service *v1.Service, ip string) (zone *pvtz.DescribeZoneInfoResponse, record *pvtz.ZoneRecordType, err error) {
+	glog.V(4).Infof("alicloud: ensure private zone record for ip(%s) with service details, \n%+v", ip, PrettyJson(service))
+
+	// update record cache after ensure
+	defer func() {
+		zone, record, err = s.updateRecordCache(service, zone, record, err)
+	}()
+
+	_, request := ExtractAnnotationRequest(service)
+
+	zone, record, err = s.findRecordByService(service)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// we will not create private zone, and user must to create it manually
+	if zone == nil {
+		glog.Infof("alicloud: config or private zone not found, " +
+			"we will skip to configure private zone")
+		return nil, nil, nil
+	}
+
+	glog.V(4).Infof("alicloud: find private zone with id %s", zone.ZoneId)
+
+	if record == nil {
+		glog.V(4).Infof("alicloud: create and bind new private zone record [%s.%s] to ip [%s]",
+			request.PrivateZoneRecordName,
+			zone.ZoneName,
+			ip)
+
+		_, err := s.c.AddZoneRecord(
+			&pvtz.AddZoneRecordArgs{
+				ZoneId: zone.ZoneId,
+				Rr:     request.PrivateZoneRecordName,
+				Type:   "A",
+				Value:  ip,
+			})
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// ensure the record has been created
+		record, err = s.findRecordByRr(zone, request.PrivateZoneRecordName)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if record == nil {
+			return nil, nil, fmt.Errorf("alicloud: unknown error on creating private zone record, it shouldn't be happend. ")
+		}
+	} else if record.Type != "A" || record.Value != ip {
+		glog.V(4).Infof("alicloud: update private zone record [%s.%s] bind to ip [%s]",
+			request.PrivateZoneRecordName,
+			zone.ZoneName,
+			ip)
+
+		err = s.c.UpdateZoneRecord(
+			&pvtz.UpdateZoneRecordArgs{
+				RecordId: record.RecordId,
+				Rr:       request.PrivateZoneRecordName,
+				Type:     "A",
+				Value:    ip,
+				Lang:     DEFAULT_LANG,
+			})
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return zone, record, nil
+}
+
+func (s *PrivateZoneClient) EnsurePrivateZoneRecordDeleted(service *v1.Service, ip string) error {
+	// need to save the resource version when deleted event
+	err := keepResourceVesion(service)
+	if err != nil {
+		glog.Warningf("alicloud: failed to save "+
+			"deleted service resourceVersion, [%s] due to [%s] ", service.Name, err.Error())
+	}
+
+	zoneInfo, record, exactMatch, err := s.findExactRecordByService(service, ip)
+	if err != nil {
+		return err
+	}
+
+	// check the ip is matched with ip address, if not, it may be user managed record
+	if !exactMatch {
+		glog.Infof("alicloud: private zone record not created by cloudprovider, skip to delete it. "+
+			"service [%s]", service.Name)
+		return nil
+	}
+
+	if zoneInfo != nil && record != nil {
+		glog.Infof("alicloud: private zone record deleted by cloudprovider. service [%s]", service.Name)
+		return s.c.DeleteZoneRecordsByRR(zoneInfo.ZoneId, record.Rr)
+	}
+
+	return nil
+}
+
+func getHostName(pz *pvtz.DescribeZoneInfoResponse, pzr *pvtz.ZoneRecordType) string {
+	var hostname string
+	if pz != nil && pzr != nil {
+		hostname = fmt.Sprintf("%s.%s", pzr.Rr, pz.ZoneName)
+	}
+	return hostname
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -26,6 +26,30 @@ spec:
   type: LoadBalancer
 ```
 
+**Private Zone** In latest version of cloud controller manager, you can use annotation to bind SLB ip to private zone record. Here is a example:
+```
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: foo
+  name: foo-service
+  namespace: default
+  annotations:
+    service.beta.kubernetes.io/alibaba-cloud-private-zone-name: "service.ali"
+    service.beta.kubernetes.io/alibaba-cloud-private-zone-record-name: "foo"
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 80
+  selector:
+    app: foo
+  type: LoadBalancer
+``` 
+
+To make private zone work, you need config RAM role of K8s master node. Find the role in [RAM control panel](https://ram.console.aliyun.com/roles) and add private zone access permissions to it.
+
 \>> **Note：**    
 
 - CloudProvider would not deal with your LoadBalancer(which was provided by user) listener by default if your cloud-controller-manager version is great equal then v1.9.3. User need to config their listener by themselves or using ```service.beta.kubernetes.io/alicloud-loadbalancer-force-override-listeners: "true"``` to force overwrite listeners. 
@@ -408,4 +432,8 @@ ps: Annotation list
 |service.beta.kubernetes.io/alicloud-loadbalancer-health-check-interval|	Time interval between two consecutive health checks. Value range: 1–50 (seconds).|None|
 |service.beta.kubernetes.io/alicloud-loadbalancer-health-check-connect-timeout|	Amount of time waiting for the response from the health check. If the backend ECS instance does not send a valid response within a specified period of time, the health check fails. value range: 1–300 (seconds).Note If the value of the parameter service.beta.kubernetes.io/alicloud-loadbalancer-health-check-connect-timeout is less than that of the parameter service.beta.kubernetes.io/alicloud-loadbalancer-health-check-interval, the parameter service.beta.kubernetes.io/alicloud-loadbalancer-health-check-connect-timeout is invalid and the timeout period equals the value of service.beta.kubernetes.io/alicloud-loadbalancer-health-check-interval.|None|
 |service.beta.kubernetes.io/alicloud-loadbalancer-health-check-timeout|	Amount of time waiting for the response from health check. If the backend ECS instance does not send a valid response within a specified period of time, the health check fails.Value range: 1–300 (seconds).Note If the value of the parameter service.beta.kubernetes.io/alicloud-loadbalancer-health-check-timeout is less than that of the parameter service.beta.kubernetes.io/alicloud-loadbalancer-health-check-interval, the parameter service.beta.kubernetes.io/alicloud-loadbalancer-health-check-timeout is invalid, and the timeout period equals the value of the parameter service.beta.kubernetes.io/alicloud-loadbalancer-health-check-interval.|None|
+|service.beta.kubernetes.io/alibaba-cloud-private-zone-name|name of PrivateZone, cloud-controller will not to create new PrivateZone|无|
+|service.beta.kubernetes.io/alibaba-cloud-private-zone-id|id of PrivateZone, when it was configured with name together, cloud provider will find PrivateZone by id first.|None|
+|service.beta.kubernetes.io/alibaba-cloud-private-zone-record-name|name of PrivateZone record.|None|
+|service.beta.kubernetes.io/alibaba-cloud-private-zone-record-ttl|ttl of PrivateZone record, 60s as default value.|60|
 

--- a/vendor/github.com/denverdino/aliyungo/acm/acm.go
+++ b/vendor/github.com/denverdino/aliyungo/acm/acm.go
@@ -1,17 +1,17 @@
 package acm
 
 import (
-	"net/http"
-	"time"
-	"fmt"
-	"errors"
-	"io/ioutil"
-	"strings"
-	"encoding/base64"
-	"crypto/sha1"
 	"crypto/hmac"
-	"strconv"
+	"crypto/sha1"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
 	"net/url"
+	"strconv"
+	"strings"
+	"time"
 )
 
 type Client struct {
@@ -148,11 +148,6 @@ func (c *Client) callApi(api string, params map[string]string, method string) (s
 		return "", err
 	}
 
-	byt, err = GbkToUtf8(byt)
-	if err != nil {
-		return "", err
-	}
-
 	body := string(byt)
 
 	if resp.StatusCode != 200 {
@@ -181,16 +176,12 @@ func (c *Client) GetAllConfigs(pageNo, pageSize int) (string, error) {
 }
 
 func (c *Client) Publish(dataId, group, content string) (string, error) {
-	bt, err := Utf8ToGbk([]byte(content))
-	if err != nil {
-		return "", err
-	}
 
 	return c.callApi("diamond-server/basestone.do?method=syncUpdateAll", map[string]string{
 		"tenant":  c.NameSpace,
 		"dataId":  dataId,
 		"group":   group,
-		"content": string(bt),
+		"content": content,
 	}, "POST")
 }
 

--- a/vendor/github.com/denverdino/aliyungo/acm/acm_test.go
+++ b/vendor/github.com/denverdino/aliyungo/acm/acm_test.go
@@ -26,7 +26,7 @@ func RunWithTest(t *testing.T, test func(client *Client, t *testing.T)) {
 	client := getClient()
 	defer client.Delete("test", "test")
 
-	_, err := client.Publish("test", "test", "test")
+	_, err := client.Publish("test", "test", "test测试")
 
 	if err != nil {
 		t.Fatalf("pulish error:%s", err)
@@ -49,6 +49,9 @@ func TestClient_GetConfig(t *testing.T) {
 		ret, err := client.GetConfig("test", "test")
 		if err != nil {
 			t.Error(err)
+		}
+		if ret != "test测试"{
+			t.Error("wrong respond content")
 		}
 		fmt.Println(ret)
 	})

--- a/vendor/github.com/denverdino/aliyungo/cdn/auth/random_uuid.go
+++ b/vendor/github.com/denverdino/aliyungo/cdn/auth/random_uuid.go
@@ -1,0 +1,97 @@
+package auth
+
+import (
+	"crypto/rand"
+	"fmt"
+	"io"
+	"os"
+	"syscall"
+	"time"
+)
+
+const (
+	// Bits is the number of bits in a UUID
+	Bits = 128
+
+	// Size is the number of bytes in a UUID
+	Size = Bits / 8
+
+	format = "%08x%04x%04x%04x%012x"
+)
+
+var (
+	// Loggerf can be used to override the default logging destination. Such
+	// log messages in this library should be logged at warning or higher.
+	Loggerf = func(format string, args ...interface{}) {}
+)
+
+// UUID represents a UUID value. UUIDs can be compared and set to other values
+// and accessed by byte.
+type UUID [Size]byte
+
+// GenerateUUID creates a new, version 4 uuid.
+func GenerateUUID() (u UUID) {
+	const (
+		// ensures we backoff for less than 450ms total. Use the following to
+		// select new value, in units of 10ms:
+		// 	n*(n+1)/2 = d -> n^2 + n - 2d -> n = (sqrt(8d + 1) - 1)/2
+		maxretries = 9
+		backoff    = time.Millisecond * 10
+	)
+
+	var (
+		totalBackoff time.Duration
+		count        int
+		retries      int
+	)
+
+	for {
+		// This should never block but the read may fail. Because of this,
+		// we just try to read the random number generator until we get
+		// something. This is a very rare condition but may happen.
+		b := time.Duration(retries) * backoff
+		time.Sleep(b)
+		totalBackoff += b
+
+		n, err := io.ReadFull(rand.Reader, u[count:])
+		if err != nil {
+			if retryOnError(err) && retries < maxretries {
+				count += n
+				retries++
+				Loggerf("error generating version 4 uuid, retrying: %v", err)
+				continue
+			}
+
+			// Any other errors represent a system problem. What did someone
+			// do to /dev/urandom?
+			panic(fmt.Errorf("error reading random number generator, retried for %v: %v", totalBackoff.String(), err))
+		}
+
+		break
+	}
+
+	u[6] = (u[6] & 0x0f) | 0x40 // set version byte
+	u[8] = (u[8] & 0x3f) | 0x80 // set high order byte 0b10{8,9,a,b}
+
+	return u
+}
+
+func (u UUID) String() string {
+	return fmt.Sprintf(format, u[:4], u[4:6], u[6:8], u[8:10], u[10:])
+}
+
+// retryOnError tries to detect whether or not retrying would be fruitful.
+func retryOnError(err error) bool {
+	switch err := err.(type) {
+	case *os.PathError:
+		return retryOnError(err.Err) // unpack the target error
+	case syscall.Errno:
+		if err == syscall.EPERM {
+			// EPERM represents an entropy pool exhaustion, a condition under
+			// which we backoff and retry.
+			return true
+		}
+	}
+
+	return false
+}

--- a/vendor/github.com/denverdino/aliyungo/cdn/auth/random_uuid_test.go
+++ b/vendor/github.com/denverdino/aliyungo/cdn/auth/random_uuid_test.go
@@ -1,0 +1,21 @@
+package auth
+
+import (
+	"testing"
+)
+
+const iterations = 1000
+
+func TestUUID4Generation(t *testing.T) {
+	for i := 0; i < iterations; i++ {
+		u := GenerateUUID()
+
+		if u[6]&0xf0 != 0x40 {
+			t.Fatalf("version byte not correctly set: %v, %08b %08b", u, u[6], u[6]&0xf0)
+		}
+
+		if u[8]&0xc0 != 0x80 {
+			t.Fatalf("top order 8th byte not correctly set: %v, %b", u, u[8])
+		}
+	}
+}

--- a/vendor/github.com/denverdino/aliyungo/cdn/auth/sign_url.go
+++ b/vendor/github.com/denverdino/aliyungo/cdn/auth/sign_url.go
@@ -1,0 +1,80 @@
+package auth
+
+import (
+	"crypto/md5"
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// An URLSigner provides URL signing utilities to sign URLs for Aliyun CDN
+// resources.
+// authentication document: https://help.aliyun.com/document_detail/85117.html
+type URLSigner struct {
+	authType string
+	privKey  string
+}
+
+// NewURLSigner returns a new signer object.
+func NewURLSigner(authType string, privKey string) *URLSigner {
+	return &URLSigner{
+		authType: authType,
+		privKey:  privKey,
+	}
+}
+
+// Sign returns a signed aliyuncdn url based on authentication type
+func (s URLSigner) Sign(uri string, expires time.Time) (string, error) {
+	r, err := url.Parse(uri)
+	if err != nil {
+		return "", fmt.Errorf("unable to parse url: %s", uri)
+	}
+
+	switch s.authType {
+	case "a":
+		return aTypeSign(r, s.privKey, expires), nil
+	case "b":
+		return bTypeSign(r, s.privKey, expires), nil
+	case "c":
+		return cTypeSign(r, s.privKey, expires), nil
+	default:
+		return "", fmt.Errorf("invalid authentication type")
+	}
+}
+
+// sign by A type authentication method.
+// authentication document: https://help.aliyun.com/document_detail/85113.html
+func aTypeSign(r *url.URL, privateKey string, expires time.Time) string {
+	//rand is a random uuid without "-"
+	rand := GenerateUUID().String()
+	// not use, "0" by default
+	uid := "0"
+	secret := fmt.Sprintf("%s-%d-%s-%s-%s", r.Path, expires.Unix(), rand, uid, privateKey)
+	hashValue := md5.Sum([]byte(secret))
+	authKey := fmt.Sprintf("%d-%s-%s-%x", expires.Unix(), rand, uid, hashValue)
+	if r.RawQuery == "" {
+		return fmt.Sprintf("%s?auth_key=%s", r.String(), authKey)
+	}
+	return fmt.Sprintf("%s&auth_key=%s", r.String(), authKey)
+
+}
+
+// sign by B type authentication method.
+// authentication document: https://help.aliyun.com/document_detail/85114.html
+func bTypeSign(r *url.URL, privateKey string, expires time.Time) string {
+	formatExp := expires.Format("200601021504")
+	secret := privateKey + formatExp + r.Path
+	hashValue := md5.Sum([]byte(secret))
+	signURL := fmt.Sprintf("%s://%s/%s/%x%s?%s", r.Scheme, r.Host, formatExp, hashValue, r.Path, r.RawQuery)
+	return signURL
+}
+
+// sign by C type authentication method.
+// authentication document: https://help.aliyun.com/document_detail/85115.html
+func cTypeSign(r *url.URL, privateKey string, expires time.Time) string {
+	hexExp := fmt.Sprintf("%x", expires.Unix())
+	secret := privateKey + r.Path + hexExp
+	hashValue := md5.Sum([]byte(secret))
+	signURL := fmt.Sprintf("%s://%s/%x/%s%s?%s", r.Scheme, r.Host, hashValue, hexExp, r.Path, r.RawQuery)
+	return signURL
+}

--- a/vendor/github.com/denverdino/aliyungo/cdn/auth/sign_url_test.go
+++ b/vendor/github.com/denverdino/aliyungo/cdn/auth/sign_url_test.go
@@ -1,0 +1,53 @@
+package auth
+
+import (
+	"crypto/md5"
+	"fmt"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+)
+
+var (
+	testSignTime = time.Unix(1541064730, 0)
+	testPrivKey  = "12345678"
+)
+
+func assertEqual(t *testing.T, name string, x, y interface{}) {
+	if !reflect.DeepEqual(x, y) {
+		t.Errorf("%s: Not equal! Expected='%v', Actual='%v'\n", name, x, y)
+		t.FailNow()
+	}
+}
+
+func TestAtypeAuth(t *testing.T) {
+	r, _ := url.Parse("https://example.com/a?foo=bar")
+	url := aTypeTest(r, testPrivKey, testSignTime)
+	assertEqual(t, "testTypeA", "https://example.com/a?foo=bar&auth_key=1541064730-0-0-f9dd5ed1e274ab4b1d5f5745344bf28b", url)
+}
+
+func TestBtypeAuth(t *testing.T) {
+	signer := NewURLSigner("b", testPrivKey)
+	url, _ := signer.Sign("https://example.com/a?foo=bar", testSignTime)
+	assertEqual(t, "testTypeB", "https://example.com/201811011732/3a19d83a89ccb00a73212420791b0123/a?foo=bar", url)
+}
+
+func TestCtypeAuth(t *testing.T) {
+	signer := NewURLSigner("c", testPrivKey)
+	url, _ := signer.Sign("https://example.com/a?foo=bar", testSignTime)
+	assertEqual(t, "testTypeC", "https://example.com/7d6b308ce87beb16d9dba32d741220f6/5bdac81a/a?foo=bar", url)
+}
+
+func aTypeTest(r *url.URL, privateKey string, expires time.Time) string {
+	//rand equals "0" in test case
+	rand := "0"
+	uid := "0"
+	secret := fmt.Sprintf("%s-%d-%s-%s-%s", r.Path, expires.Unix(), rand, uid, privateKey)
+	hashValue := md5.Sum([]byte(secret))
+	authKey := fmt.Sprintf("%d-%s-%s-%x", expires.Unix(), rand, uid, hashValue)
+	if r.RawQuery == "" {
+		return fmt.Sprintf("%s?auth_key=%s", r.String(), authKey)
+	}
+	return fmt.Sprintf("%s&auth_key=%s", r.String(), authKey)
+}

--- a/vendor/github.com/denverdino/aliyungo/common/client.go
+++ b/vendor/github.com/denverdino/aliyungo/common/client.go
@@ -96,7 +96,7 @@ func (client *Client) NewInitForAssumeRole(endpoint, version, accessKeyId, acces
 //getLocationEndpoint
 func (client *Client) getEndpointByLocation() string {
 	locationClient := NewLocationClient(client.AccessKeyId, client.AccessKeySecret, client.securityToken)
-	//locationClient.SetDebug(true)
+	locationClient.SetDebug(true)
 	return locationClient.DescribeOpenAPIEndpoint(client.regionID, client.serviceCode)
 }
 

--- a/vendor/github.com/denverdino/aliyungo/cs/client.go
+++ b/vendor/github.com/denverdino/aliyungo/cs/client.go
@@ -76,6 +76,11 @@ func (client *Client) SetUserAgent(userAgent string) {
 	client.userAgent = userAgent
 }
 
+// SetEndpoint sets customer endpoint
+func (client *Client) SetEndpoint(endpoint string) {
+	client.endpoint = endpoint
+}
+
 type Request struct {
 	Method          string
 	URL             string

--- a/vendor/github.com/denverdino/aliyungo/cs/clusters.go
+++ b/vendor/github.com/denverdino/aliyungo/cs/clusters.go
@@ -27,7 +27,14 @@ const (
 	DeleteFailed = ClusterState("deleteFailed")
 	Deleted      = ClusterState("deleted")
 	InActive     = ClusterState("inactive")
+
+	ClusterTypeKubernetes        = "Kubernetes"
+	ClusterTypeManagedKubernetes = "ManagedKubernetes"
 )
+
+var NodeStableClusterState = []ClusterState{Running, Updating, Failed, DeleteFailed, Deleted, InActive}
+
+var NodeUnstableClusterState = []ClusterState{Initial, Scaling, Deleting}
 
 type NodeStatus struct {
 	Health   int64 `json:"health"`
@@ -129,33 +136,50 @@ type KubernetesStackArgs struct {
 }
 
 type KubernetesCreationArgs struct {
-	DisableRollback          bool             `json:"disable_rollback"`
-	Name                     string           `json:"name"`
-	TimeoutMins              int64            `json:"timeout_mins"`
-	ZoneId                   string           `json:"zoneid,omitempty"`
-	VPCID                    string           `json:"vpcid,omitempty"`
-	VSwitchId                string           `json:"vswitchid,omitempty"`
-	ContainerCIDR            string           `json:"container_cidr,omitempty"`
-	ServiceCIDR              string           `json:"service_cidr,omitempty"`
+	DisableRollback bool   `json:"disable_rollback"`
+	Name            string `json:"name"`
+	TimeoutMins     int64  `json:"timeout_mins"`
+	ZoneId          string `json:"zoneid,omitempty"`
+	VPCID           string `json:"vpcid,omitempty"`
+	VSwitchId       string `json:"vswitchid,omitempty"`
+	ImageId         string `json:"image_id"`
+	ContainerCIDR   string `json:"container_cidr,omitempty"`
+	ServiceCIDR     string `json:"service_cidr,omitempty"`
+
 	MasterInstanceType       string           `json:"master_instance_type,omitempty"`
 	MasterSystemDiskSize     int64            `json:"master_system_disk_size,omitempty"`
 	MasterSystemDiskCategory ecs.DiskCategory `json:"master_system_disk_category,omitempty"`
+
+	MasterInstanceChargeType string `json:"master_instance_charge_type"`
+	MasterPeriodUnit         string `json:"master_period_unit"`
+	MasterPeriod             int    `json:"master_period"`
+	MasterAutoRenew          bool   `json:"master_auto_renew"`
+	MasterAutoRenewPeriod    int    `json:"master_auto_renew_period"`
+
 	WorkerInstanceType       string           `json:"worker_instance_type,omitempty"`
 	WorkerSystemDiskSize     int64            `json:"worker_system_disk_size,omitempty"`
 	WorkerSystemDiskCategory ecs.DiskCategory `json:"worker_system_disk_category,omitempty"`
 	WorkerDataDisk           bool             `json:"worker_data_disk"`
 	WorkerDataDiskCategory   string           `json:"worker_data_disk_category,omitempty"`
 	WorkerDataDiskSize       int64            `json:"worker_data_disk_size,omitempty"`
-	LoginPassword            string           `json:"login_password,omitempty"`
-	KeyPair                  string           `json:"key_pair,omitempty"`
-	NumOfNodes               int64            `json:"num_of_nodes,omitempty"`
-	SNatEntry                bool             `json:"snat_entry"`
-	SSHFlags                 bool             `json:"ssh_flags"`
-	CloudMonitorFlags        bool             `json:"cloud_monitor_flags"`
-	NodeCIDRMask             string           `json:"node_cidr_mask,omitempty"`
-	LoggingType              string           `json:"logging_type,omitempty"`
-	SLSProjectName           string           `json:"sls_project_name,omitempty"`
-	PublicSLB                bool             `json:"public_slb"`
+
+	WorkerInstanceChargeType string `json:"worker_instance_charge_type"`
+	WorkerPeriodUnit         string `json:"worker_period_unit"`
+	WorkerPeriod             int    `json:"worker_period"`
+	WorkerAutoRenew          bool   `json:"worker_auto_renew"`
+	WorkerAutoRenewPeriod    int    `json:"worker_auto_renew_period"`
+
+	LoginPassword     string `json:"login_password,omitempty"`
+	KeyPair           string `json:"key_pair,omitempty"`
+	UserCA            string `json:"user_ca,omitempty"`
+	NumOfNodes        int64  `json:"num_of_nodes,omitempty"`
+	SNatEntry         bool   `json:"snat_entry"`
+	SSHFlags          bool   `json:"ssh_flags"`
+	CloudMonitorFlags bool   `json:"cloud_monitor_flags"`
+	NodeCIDRMask      string `json:"node_cidr_mask,omitempty"`
+	LoggingType       string `json:"logging_type,omitempty"`
+	SLSProjectName    string `json:"sls_project_name,omitempty"`
+	PublicSLB         bool   `json:"public_slb"`
 
 	ClusterType string `json:"cluster_type"`
 	Network     string `json:"network,omitempty"`
@@ -165,22 +189,31 @@ type KubernetesCreationArgs struct {
 }
 
 type KubernetesMultiAZCreationArgs struct {
-	DisableRollback          bool             `json:"disable_rollback"`
-	Name                     string           `json:"name"`
-	TimeoutMins              int64            `json:"timeout_mins"`
-	ClusterType              string           `json:"cluster_type"`
-	MultiAZ                  bool             `json:"multi_az"`
-	VPCID                    string           `json:"vpcid,omitempty"`
-	ContainerCIDR            string           `json:"container_cidr"`
-	ServiceCIDR              string           `json:"service_cidr"`
-	VSwitchIdA               string           `json:"vswitch_id_a,omitempty"`
-	VSwitchIdB               string           `json:"vswitch_id_b,omitempty"`
-	VSwitchIdC               string           `json:"vswitch_id_c,omitempty"`
+	DisableRollback bool   `json:"disable_rollback"`
+	Name            string `json:"name"`
+	TimeoutMins     int64  `json:"timeout_mins"`
+	ClusterType     string `json:"cluster_type"`
+	MultiAZ         bool   `json:"multi_az"`
+	VPCID           string `json:"vpcid,omitempty"`
+	ImageId         string `json:"image_id"`
+	ContainerCIDR   string `json:"container_cidr"`
+	ServiceCIDR     string `json:"service_cidr"`
+	VSwitchIdA      string `json:"vswitch_id_a,omitempty"`
+	VSwitchIdB      string `json:"vswitch_id_b,omitempty"`
+	VSwitchIdC      string `json:"vswitch_id_c,omitempty"`
+
 	MasterInstanceTypeA      string           `json:"master_instance_type_a,omitempty"`
 	MasterInstanceTypeB      string           `json:"master_instance_type_b,omitempty"`
 	MasterInstanceTypeC      string           `json:"master_instance_type_c,omitempty"`
 	MasterSystemDiskCategory ecs.DiskCategory `json:"master_system_disk_category"`
 	MasterSystemDiskSize     int64            `json:"master_system_disk_size"`
+
+	MasterInstanceChargeType string `json:"master_instance_charge_type"`
+	MasterPeriodUnit         string `json:"master_period_unit"`
+	MasterPeriod             int    `json:"master_period"`
+	MasterAutoRenew          bool   `json:"master_auto_renew"`
+	MasterAutoRenewPeriod    int    `json:"master_auto_renew_period"`
+
 	WorkerInstanceTypeA      string           `json:"worker_instance_type_a,omitempty"`
 	WorkerInstanceTypeB      string           `json:"worker_instance_type_b,omitempty"`
 	WorkerInstanceTypeC      string           `json:"worker_instance_type_c,omitempty"`
@@ -189,17 +222,25 @@ type KubernetesMultiAZCreationArgs struct {
 	WorkerDataDisk           bool             `json:"worker_data_disk"`
 	WorkerDataDiskCategory   string           `json:"worker_data_disk_category"`
 	WorkerDataDiskSize       int64            `json:"worker_data_disk_size"`
-	NumOfNodesA              int64            `json:"num_of_nodes_a"`
-	NumOfNodesB              int64            `json:"num_of_nodes_b"`
-	NumOfNodesC              int64            `json:"num_of_nodes_c"`
-	LoginPassword            string           `json:"login_password,omitempty"`
-	KeyPair                  string           `json:"key_pair,omitempty"`
-	SSHFlags                 bool             `json:"ssh_flags"`
-	CloudMonitorFlags        bool             `json:"cloud_monitor_flags"`
-	NodeCIDRMask             string           `json:"node_cidr_mask,omitempty"`
-	LoggingType              string           `json:"logging_type,omitempty"`
-	SLSProjectName           string           `json:"sls_project_name,omitempty"`
-	PublicSLB                bool             `json:"public_slb"`
+
+	WorkerInstanceChargeType string `json:"worker_instance_charge_type"`
+	WorkerPeriodUnit         string `json:"worker_period_unit"`
+	WorkerPeriod             int    `json:"worker_period"`
+	WorkerAutoRenew          bool   `json:"worker_auto_renew"`
+	WorkerAutoRenewPeriod    int    `json:"worker_auto_renew_period"`
+
+	NumOfNodesA       int64  `json:"num_of_nodes_a"`
+	NumOfNodesB       int64  `json:"num_of_nodes_b"`
+	NumOfNodesC       int64  `json:"num_of_nodes_c"`
+	LoginPassword     string `json:"login_password,omitempty"`
+	KeyPair           string `json:"key_pair,omitempty"`
+	UserCA            string `json:"user_ca,omitempty"`
+	SSHFlags          bool   `json:"ssh_flags"`
+	CloudMonitorFlags bool   `json:"cloud_monitor_flags"`
+	NodeCIDRMask      string `json:"node_cidr_mask,omitempty"`
+	LoggingType       string `json:"logging_type,omitempty"`
+	SLSProjectName    string `json:"sls_project_name,omitempty"`
+	PublicSLB         bool   `json:"public_slb"`
 
 	KubernetesVersion string `json:"kubernetes_version,omitempty"`
 	Network           string `json:"network,omitempty"`
@@ -224,27 +265,47 @@ type KubernetesClusterMetaData struct {
 }
 
 type KubernetesClusterParameter struct {
-	ServiceCidr              string `json:"ServiceCIDR"`
-	ContainerCidr            string `json:"ContainerCIDR"`
-	DockerVersion            string `json:"DockerVersion"`
-	EtcdVersion              string `json:"EtcdVersion"`
-	KubernetesVersion        string `json:"KubernetesVersion"`
-	VPCID                    string `json:"VpcId"`
-	KeyPair                  string `json:"KeyPair"`
+	ServiceCidr       string `json:"ServiceCIDR"`
+	ContainerCidr     string `json:"ContainerCIDR"`
+	DockerVersion     string `json:"DockerVersion"`
+	EtcdVersion       string `json:"EtcdVersion"`
+	KubernetesVersion string `json:"KubernetesVersion"`
+	VPCID             string `json:"VpcId"`
+	ImageId           string `json:"ImageId"`
+	KeyPair           string `json:"KeyPair"`
+
 	MasterSystemDiskCategory string `json:"MasterSystemDiskCategory"`
 	MasterSystemDiskSize     string `json:"MasterSystemDiskSize"`
+	MasterImageId            string `json:"MasterImageId"`
+
+	MasterInstanceChargeType string `json:"MasterInstanceChargeType"`
+	MasterPeriodUnit         string `json:"MasterPeriodUnit"`
+	MasterPeriod             string `json:"MasterPeriod"`
+	MasterAutoRenew          *bool
+	RawMasterAutoRenew       string `json:"MasterAutoRenew"`
+	MasterAutoRenewPeriod    string `json:"MasterAutoRenewPeriod"`
+
 	WorkerSystemDiskCategory string `json:"WorkerSystemDiskCategory"`
 	WorkerSystemDiskSize     string `json:"WorkerSystemDiskSize"`
-	WorkerDataDisk           bool
+	WorkerImageId            string `json:"WorkerImageId"`
+	WorkerDataDisk           *bool
 	RawWorkerDataDisk        string `json:"WorkerDataDisk"`
 	WorkerDataDiskCategory   string `json:"WorkerDataDiskCategory"`
 	WorkerDataDiskSize       string `json:"WorkerDataDiskSize"`
-	ZoneId                   string `json:"ZoneId"`
-	NodeCIDRMask             string `json:"NodeCIDRMask"`
-	LoggingType              string `json:"LoggingType"`
-	SLSProjectName           string `json:"SLSProjectName"`
-	PublicSLB                bool
-	RawPublicSLB             string `json:"PublicSLB"`
+
+	WorkerInstanceChargeType string `json:"WorkerInstanceChargeType"`
+	WorkerPeriodUnit         string `json:"WorkerPeriodUnit"`
+	WorkerPeriod             string `json:"WorkerPeriod"`
+	WorkerAutoRenew          *bool
+	RawWorkerAutoRenew       string `json:"WorkerAutoRenew"`
+	WorkerAutoRenewPeriod    string `json:"WorkerAutoRenewPeriod"`
+
+	ZoneId         string `json:"ZoneId"`
+	NodeCIDRMask   string `json:"NodeCIDRMask"`
+	LoggingType    string `json:"LoggingType"`
+	SLSProjectName string `json:"SLSProjectName"`
+	PublicSLB      *bool
+	RawPublicSLB   string `json:"PublicSLB"`
 
 	// Single AZ
 	MasterInstanceType string `json:"MasterInstanceType"`
@@ -301,21 +362,29 @@ func (client *Client) DescribeKubernetesCluster(id string) (cluster KubernetesCl
 	if err != nil {
 		return cluster, err
 	}
+
 	var metaData KubernetesClusterMetaData
 	err = json.Unmarshal([]byte(cluster.RawMetaData), &metaData)
+	if err != nil {
+		return cluster, err
+	}
 	cluster.MetaData = metaData
 	cluster.RawMetaData = ""
-	cluster.Parameters.WorkerDataDisk = convertStringToBool(cluster.Parameters.RawWorkerDataDisk)
-	cluster.Parameters.PublicSLB = convertStringToBool(cluster.Parameters.RawPublicSLB)
+
+	cluster.Parameters.WorkerDataDisk = parseBoolOrNil(cluster.Parameters.RawWorkerDataDisk)
+	cluster.Parameters.PublicSLB = parseBoolOrNil(cluster.Parameters.RawPublicSLB)
+	cluster.Parameters.MasterAutoRenew = parseBoolOrNil(cluster.Parameters.RawMasterAutoRenew)
+	cluster.Parameters.WorkerAutoRenew = parseBoolOrNil(cluster.Parameters.RawWorkerAutoRenew)
+
 	return
 }
 
-func convertStringToBool(raw string) bool {
-	if raw == "True" {
-		return true
-	} else {
-		return false
+func parseBoolOrNil(rawField string) *bool {
+	boolVal, err := strconv.ParseBool(rawField)
+	if err == nil {
+		return &boolVal
 	}
+	return nil
 }
 
 type ClusterResizeArgs struct {
@@ -383,6 +452,19 @@ func (client *Client) GetClusterCerts(id string) (certs ClusterCerts, err error)
 	return
 }
 
+type ClusterEndpoints struct {
+	ApiServerEndpoint         string `json:"api_server_endpoint"`
+	DashboardEndpoint         string `json:"dashboard_endpoint"`
+	MiranaEndpoint            string `json:"mirana_endpoint"`
+	ReverseTunnelEndpoint     string `json:"reverse_tunnel_endpoint"`
+	IntranetApiServerEndpoint string `json:"intranet_api_server_endpoint"`
+}
+
+func (client *Client) GetClusterEndpoints(id string) (clusterEndpoints ClusterEndpoints, err error) {
+	err = client.Invoke("", http.MethodGet, "/clusters/"+id+"/endpoints", nil, nil, &clusterEndpoints)
+	return
+}
+
 type ClusterConfig struct {
 	Config string `json:"config"`
 }
@@ -423,7 +505,8 @@ func (client *Client) GetKubernetesClusterNodes(id string, pagination common.Pag
 
 const ClusterDefaultTimeout = 300
 const DefaultWaitForInterval = 10
-const DefaultPreSleepTime = 240
+const DefaultPreCheckSleepTime = 20
+const DefaultPreSleepTime = 220
 
 // WaitForCluster waits for instance to given status
 // when instance.NotFound wait until timeout
@@ -431,15 +514,23 @@ func (client *Client) WaitForClusterAsyn(clusterId string, status ClusterState, 
 	if timeout <= 0 {
 		timeout = ClusterDefaultTimeout
 	}
+
+	// Sleep 20 second to check cluster creating or failed
+	sleep := math.Min(float64(timeout), float64(DefaultPreCheckSleepTime))
+	time.Sleep(time.Duration(sleep) * time.Second)
+
 	cluster, err := client.DescribeCluster(clusterId)
 	if err != nil {
 		return err
+	} else if cluster.State == Failed {
+		return fmt.Errorf("Waitting for cluster %s %s failed. Looking the specified reason in the web console.", clusterId, status)
 	} else if cluster.State == status {
 		//TODO
 		return nil
 	}
+
 	// Create or Reset cluster usually cost at least 4 min, so there will sleep a long time before polling
-	sleep := math.Min(float64(timeout), float64(DefaultPreSleepTime))
+	sleep = math.Min(float64(timeout), float64(DefaultPreSleepTime))
 	time.Sleep(time.Duration(sleep) * time.Second)
 
 	for {

--- a/vendor/github.com/denverdino/aliyungo/cs/clusters_test.go
+++ b/vendor/github.com/denverdino/aliyungo/cs/clusters_test.go
@@ -42,7 +42,7 @@ func TestClient_DescribeKubernetesClusters(t *testing.T) {
 	}
 
 	for _, cluster := range clusters {
-		if cluster.ClusterType != "Kubernetes" {
+		if cluster.ClusterType != "Kubernetes" && cluster.ClusterType != "ManagedKubernetes" {
 			continue
 		}
 		t.Logf("Cluster: %++v", cluster)
@@ -52,16 +52,35 @@ func TestClient_DescribeKubernetesClusters(t *testing.T) {
 		}
 		t.Logf("Cluster Describe: %++v", c)
 		t.Logf("Cluster KeyPair %v", c.Parameters.KeyPair)
-		t.Logf("Cluster RawWorkerDataDisk %v", c.Parameters.RawWorkerDataDisk)
-		t.Logf("Cluster WorkerDataDisk %v", c.Parameters.WorkerDataDisk)
-		if c.Parameters.WorkerDataDisk {
+		t.Logf("Cluster WorkerDataDisk %v", *c.Parameters.WorkerDataDisk)
+
+		t.Logf("Cluster MasterInstanceChargeType %v", c.Parameters.MasterInstanceChargeType)
+		if c.Parameters.MasterInstanceChargeType == "PrePaid" {
+			t.Logf("Cluster MasterAutoRenew %v", *c.Parameters.MasterAutoRenew)
+			t.Logf("Cluster MasterAutoRenewPeriod %v", c.Parameters.MasterAutoRenewPeriod)
+			t.Logf("Cluster MasterPeriod %v", c.Parameters.MasterPeriod)
+			t.Logf("Cluster MasterPeriodUnit %v", c.Parameters.MasterPeriodUnit)
+		}
+
+		t.Logf("Cluster WorkerInstanceChargeType %v", c.Parameters.WorkerInstanceChargeType)
+		if c.Parameters.WorkerInstanceChargeType == "PrePaid" {
+			t.Logf("Cluster WorkerAutoRenew %v", *c.Parameters.WorkerAutoRenew)
+			t.Logf("Cluster WorkerAutoRenewPeriod %v", c.Parameters.WorkerAutoRenewPeriod)
+			t.Logf("Cluster WorkerPeriod %v", c.Parameters.WorkerPeriod)
+			t.Logf("Cluster WorkerPeriodUnit %v", c.Parameters.WorkerPeriodUnit)
+		}
+
+		if c.Parameters.WorkerDataDisk != nil && *c.Parameters.WorkerDataDisk {
 			t.Logf("Cluster WorkerDataDiskSize %v", c.Parameters.WorkerDataDiskSize)
 			t.Logf("Cluster WorkerDataDiskCategory %v", c.Parameters.WorkerDataDiskCategory)
 		}
+		t.Logf("Cluster ImageId %v", c.Parameters.ImageId)
 		t.Logf("Cluster NodeCIDRMask %v", c.Parameters.NodeCIDRMask)
 		t.Logf("Cluster LoggingType %v", c.Parameters.LoggingType)
 		t.Logf("Cluster SLSProjectName %v", c.Parameters.SLSProjectName)
-		t.Logf("Cluster PublicSLB %v", c.Parameters.PublicSLB)
+		if c.Parameters.PublicSLB != nil {
+			t.Logf("Cluster PublicSLB %v", *c.Parameters.PublicSLB)
+		}
 
 		if c.MetaData.MultiAZ || c.MetaData.SubClass == "3az" {
 			t.Logf("%v is a MultiAZ kubernetes cluster", c.ClusterID)
@@ -75,7 +94,11 @@ func TestClient_DescribeKubernetesClusters(t *testing.T) {
 			t.Logf("Cluster NumOfNodeB %v", c.Parameters.NumOfNodesB)
 			t.Logf("Cluster NumOfNodeC %v", c.Parameters.NumOfNodesC)
 		} else {
-			t.Logf("%v is a single kubernetes cluster", c.ClusterID)
+			if cluster.ClusterType == "ManagedKubernetes" {
+				t.Logf("%v is a Managed kubernetes cluster", c.ClusterID)
+			} else {
+				t.Logf("%v is a SingleAZ kubernetes cluster", c.ClusterID)
+			}
 			t.Logf("Cluster VSW ID %v", c.Parameters.VSwitchID)
 			t.Logf("Cluster MasterInstanceType %v", c.Parameters.MasterInstanceType)
 			t.Logf("Cluster NumOfNode %v", c.Parameters.NumOfNodes)
@@ -106,6 +129,16 @@ func TestListClusters(t *testing.T) {
 		t.Logf("Cluster certs: %++v", certs)
 
 	}
+}
+
+func _TestGetClusterEndpoints(t *testing.T) {
+	client := NewTestClientForDebug()
+	clusterId := "c213c31b97430433c87afe4852b6a08ef"
+	clusterEndpoints, err := client.GetClusterEndpoints(clusterId)
+	if err != nil {
+		t.Fatalf("Failed to GetClusterEndpoints: %v", err)
+	}
+	t.Logf("Succeed getting clusterEndpoints %v", clusterEndpoints)
 }
 
 func _TestCreateClusters(t *testing.T) {
@@ -178,42 +211,98 @@ func _TestCreateKubernetesCluster(t *testing.T) {
 	t.Logf("Cluster: %++v", cluster)
 }
 
+func _TestCreateManagedKubernetesCluster(t *testing.T) {
+
+	client := NewTestClientForDebug()
+
+	args := KubernetesCreationArgs{
+		Name:            "single-managed-az-k8s",
+		ClusterType:     "ManagedKubernetes",
+		DisableRollback: true,
+		//VPCID:                    "vpc-id",
+		//VSwitchId:                "vsw-id",
+		ZoneId:                   "cn-hangzhou-g",
+		SNatEntry:                true,
+		NumOfNodes:               2,
+		MasterInstanceType:       "ecs.sn1ne.large",
+		MasterSystemDiskCategory: "cloud_efficiency",
+		MasterSystemDiskSize:     40,
+		WorkerInstanceType:       "ecs.sn1ne.large",
+		WorkerSystemDiskCategory: "cloud_efficiency",
+		WorkerSystemDiskSize:     40,
+		SSHFlags:                 true,
+		ContainerCIDR:            "172.16.0.0/16",
+		ServiceCIDR:              "172.19.0.0/20",
+		LoginPassword:            "test-password123",
+		WorkerDataDisk:           true,
+		WorkerDataDiskCategory:   "cloud_efficiency",
+		WorkerDataDiskSize:       100,
+		PublicSLB:                true,
+		NodeCIDRMask:             "25",
+		LoggingType:              "SLS",
+		SLSProjectName:           "k8s-test-my-terraform-singleaz",
+	}
+	cluster, err := client.CreateKubernetesCluster(common.Hangzhou, &args)
+	if err != nil {
+		t.Fatalf("Failed to CreateKubernetesCluster: %v", err)
+	}
+
+	t.Logf("Cluster: %++v", cluster)
+}
+
 func _TestCreateKubernetesMultiAZCluster(t *testing.T) {
 
 	client := NewTestClientForDebug()
 
 	args := KubernetesMultiAZCreationArgs{
-		Name:                     "multiaz-test1",
-		ClusterType:              "Kubernetes",
-		DisableRollback:          true,
-		MultiAZ:                  true,
-		VPCID:                    "vpc-id",
-		VSwitchIdA:               "vsw-id1",
-		VSwitchIdB:               "vsw-id2",
-		VSwitchIdC:               "vsw-id3",
-		NumOfNodesA:              1,
-		NumOfNodesB:              1,
-		NumOfNodesC:              1,
-		MasterInstanceTypeA:      "ecs.sn1ne.large",
-		MasterInstanceTypeB:      "ecs.sn1ne.large",
-		MasterInstanceTypeC:      "ecs.sn1ne.large",
+		Name:            "multiaz-test",
+		ClusterType:     "Kubernetes",
+		DisableRollback: true,
+		MultiAZ:         true,
+		VPCID:           "vpc-id",
+		VSwitchIdA:      "vsw-id1",
+		VSwitchIdB:      "vsw-id2",
+		VSwitchIdC:      "vsw-id3",
+		NumOfNodesA:     1,
+		NumOfNodesB:     1,
+		NumOfNodesC:     1,
+
+		MasterInstanceTypeA:      "ecs.ic5.xlarge",
+		MasterInstanceTypeB:      "ecs.ic5.xlarge",
+		MasterInstanceTypeC:      "ecs.ic5.xlarge",
 		MasterSystemDiskCategory: "cloud_efficiency",
 		MasterSystemDiskSize:     40,
-		WorkerInstanceTypeA:      "ecs.sn1ne.large",
-		WorkerInstanceTypeB:      "ecs.sn1ne.large",
-		WorkerInstanceTypeC:      "ecs.sn1ne.large",
+
+		MasterInstanceChargeType: "PrePaid",
+		MasterPeriodUnit:         "Week",
+		MasterPeriod:             1,
+		MasterAutoRenew:          true,
+		MasterAutoRenewPeriod:    1,
+
+		WorkerInstanceTypeA:      "ecs.ic5.xlarge",
+		WorkerInstanceTypeB:      "ecs.ic5.xlarge",
+		WorkerInstanceTypeC:      "ecs.ic5.xlarge",
 		WorkerSystemDiskCategory: "cloud_efficiency",
 		WorkerSystemDiskSize:     40,
-		SSHFlags:                 true,
-		ContainerCIDR:            "172.17.0.0/16",
-		ServiceCIDR:              "172.20.0.0/20",
-		LoginPassword:            "test-password123",
-		WorkerDataDisk:           true,
-		WorkerDataDiskCategory:   "cloud_efficiency",
-		WorkerDataDiskSize:       100,
-		NodeCIDRMask:             "25",
-		LoggingType:              "SLS",
-		SLSProjectName:           "k8s-test-my-terraform",
+
+		WorkerInstanceChargeType: "PrePaid",
+		WorkerPeriodUnit:         "Week",
+		WorkerPeriod:             1,
+		WorkerAutoRenew:          true,
+		WorkerAutoRenewPeriod:    1,
+
+		SSHFlags:               true,
+		ContainerCIDR:          "172.20.0.0/16",
+		ServiceCIDR:            "172.21.0.0/20",
+		LoginPassword:          "test-password123",
+		ImageId:                "centos_7_03_64_20G_alibase_20170818.vhd",
+		KubernetesVersion:      "1.11.2",
+		WorkerDataDisk:         true,
+		WorkerDataDiskCategory: "cloud_efficiency",
+		WorkerDataDiskSize:     100,
+		NodeCIDRMask:           "25",
+		LoggingType:            "SLS",
+		SLSProjectName:         "k8s-test-my-terraform",
 	}
 	cluster, err := client.CreateKubernetesMultiAZCluster(common.Hangzhou, &args)
 	if err != nil {

--- a/vendor/github.com/denverdino/aliyungo/ecs/eni.go
+++ b/vendor/github.com/denverdino/aliyungo/ecs/eni.go
@@ -2,6 +2,7 @@ package ecs
 
 import (
 	"fmt"
+	"github.com/denverdino/aliyungo/util"
 	"time"
 
 	"github.com/denverdino/aliyungo/common"
@@ -46,9 +47,34 @@ type NetworkInterfaceType struct {
 	NetworkInterfaceId   string
 	NetworkInterfaceName string
 	PrimaryIpAddress     string
-	MacAddress           string
-	Status               string
-	PrivateIpAddress     string
+	PrivateIpSets        struct {
+		PrivateIpSet []PrivateIpType
+	}
+	MacAddress         string
+	Status             string
+	Type               string
+	VpcId              string
+	VSwitchId          string
+	ZoneId             string
+	AssociatedPublicIp AssociatedPublicIp
+	SecurityGroupIds   struct {
+		SecurityGroupId []string
+	}
+	Description      string
+	InstanceId       string
+	CreationTime     util.ISO6801Time
+	PrivateIpAddress string
+}
+
+type PrivateIpType struct {
+	PrivateIpAddress   string
+	Primary            bool
+	AssociatedPublicIp AssociatedPublicIp
+}
+
+type AssociatedPublicIp struct {
+	PublicIpAddress string
+	AllocationId    string
 }
 
 type DescribeNetworkInterfacesResponse struct {
@@ -80,6 +106,23 @@ type ModifyNetworkInterfaceAttributeArgs struct {
 	Description          string
 }
 type ModifyNetworkInterfaceAttributeResponse common.Response
+
+type UnassignPrivateIpAddressesArgs struct {
+	RegionId           common.Region
+	NetworkInterfaceId string
+	PrivateIpAddress   []string `query:"list"`
+}
+
+type UnassignPrivateIpAddressesResponse common.Response
+
+type AssignPrivateIpAddressesArgs struct {
+	RegionId                       common.Region
+	NetworkInterfaceId             string
+	PrivateIpAddress               []string `query:"list"` // optional
+	SecondaryPrivateIpAddressCount int      // optional
+}
+
+type AssignPrivateIpAddressesResponse common.Response
 
 func (client *Client) CreateNetworkInterface(args *CreateNetworkInterfaceArgs) (resp *CreateNetworkInterfaceResponse, err error) {
 	resp = &CreateNetworkInterfaceResponse{}
@@ -114,6 +157,18 @@ func (client *Client) DetachNetworkInterface(args *DetachNetworkInterfaceArgs) (
 func (client *Client) ModifyNetworkInterfaceAttribute(args *ModifyNetworkInterfaceAttributeArgs) (resp *ModifyNetworkInterfaceAttributeResponse, err error) {
 	resp = &ModifyNetworkInterfaceAttributeResponse{}
 	err = client.Invoke("ModifyNetworkInterfaceAttribute", args, resp)
+	return resp, err
+}
+
+func (client *Client) UnassignPrivateIpAddresses(args *UnassignPrivateIpAddressesArgs) (resp *UnassignPrivateIpAddressesResponse, err error) {
+	resp = &UnassignPrivateIpAddressesResponse{}
+	err = client.Invoke("UnassignPrivateIpAddresses", args, resp)
+	return resp, err
+}
+
+func (client *Client) AssignPrivateIpAddresses(args *AssignPrivateIpAddressesArgs) (resp *AssignPrivateIpAddressesResponse, err error) {
+	resp = &AssignPrivateIpAddressesResponse{}
+	err = client.Invoke("AssignPrivateIpAddresses", args, resp)
 	return resp, err
 }
 

--- a/vendor/github.com/denverdino/aliyungo/ecs/eni_test.go
+++ b/vendor/github.com/denverdino/aliyungo/ecs/eni_test.go
@@ -1,0 +1,62 @@
+package ecs
+
+import (
+	"github.com/denverdino/aliyungo/common"
+	"testing"
+	"time"
+)
+
+func TestAssignPrivateIPAddresses(t *testing.T) {
+	req := AssignPrivateIpAddressesArgs{
+		RegionId:           common.Beijing,
+		NetworkInterfaceId: "eni-testeni",
+		PrivateIpAddress:   []string{"192.168.1.200", "192.168.1.201"},
+	}
+	client := NewTestClient()
+	_, err := client.AssignPrivateIpAddresses(&req)
+	if err != nil {
+		t.Errorf("Failed to AssignPrivateIpAddresses: %v", err)
+	}
+
+	time.Sleep(5 * time.Second)
+
+	req = AssignPrivateIpAddressesArgs{
+		RegionId:                       common.Beijing,
+		NetworkInterfaceId:             "eni-testeni",
+		SecondaryPrivateIpAddressCount: 1,
+	}
+
+	_, err = client.AssignPrivateIpAddresses(&req)
+	if err != nil {
+		t.Errorf("Failed to AssignPrivateIpAddresses: %v", err)
+	}
+}
+
+func TestDescribeENI(t *testing.T) {
+	req := DescribeNetworkInterfacesArgs{
+		RegionId:           common.Beijing,
+		NetworkInterfaceId: []string{"eni-testeni"},
+	}
+	client := NewTestClient()
+	resp, err := client.DescribeNetworkInterfaces(&req)
+	if err != nil {
+		t.Errorf("Failed to DescribeNetworkInterfaces: %v", err)
+	}
+	if len(resp.NetworkInterfaceSets.NetworkInterfaceSet[0].PrivateIpSets.PrivateIpSet) != 4 {
+		t.Errorf("assert network private ip count be 4, %+v", resp.NetworkInterfaceSets.NetworkInterfaceSet[0].PrivateIpSets.PrivateIpSet)
+	}
+	t.Logf("%+v", resp.NetworkInterfaceSets.NetworkInterfaceSet[0])
+}
+
+func TestUnAssignPrivateIPAddresses(t *testing.T) {
+	req := UnassignPrivateIpAddressesArgs{
+		RegionId:           common.Beijing,
+		NetworkInterfaceId: "eni-testeni",
+		PrivateIpAddress:   []string{"192.168.1.200", "192.168.1.201"},
+	}
+	client := NewTestClient()
+	_, err := client.UnassignPrivateIpAddresses(&req)
+	if err != nil {
+		t.Errorf("Failed to UnAssignPrivateIpAddresses: %v", err)
+	}
+}

--- a/vendor/github.com/denverdino/aliyungo/ecs/instance_types.go
+++ b/vendor/github.com/denverdino/aliyungo/ecs/instance_types.go
@@ -9,18 +9,19 @@ type DescribeInstanceTypesArgs struct {
 //
 // You can read doc at http://docs.aliyun.com/#/pub/ecs/open-api/datatype&instancetypeitemtype
 type InstanceTypeItemType struct {
-	InstanceTypeId       string
-	CpuCoreCount         int
-	MemorySize           float64
-	InstanceTypeFamily   string
-	GPUAmount            int
-	GPUSpec              string
-	InitialCredit        int
-	BaselineCredit       int
-	EniQuantity          int
-	LocalStorageCapacity int
-	LocalStorageAmount   int
-	LocalStorageCategory string
+	InstanceTypeId              string
+	CpuCoreCount                int
+	MemorySize                  float64
+	InstanceTypeFamily          string
+	GPUAmount                   int
+	GPUSpec                     string
+	InitialCredit               int
+	BaselineCredit              int
+	EniQuantity                 int
+	EniPrivateIpAddressQuantity int
+	LocalStorageCapacity        int
+	LocalStorageAmount          int
+	LocalStorageCategory        string
 }
 
 type DescribeInstanceTypesResponse struct {

--- a/vendor/github.com/denverdino/aliyungo/ecs/vpcs.go
+++ b/vendor/github.com/denverdino/aliyungo/ecs/vpcs.go
@@ -81,6 +81,9 @@ type VpcSetType struct {
 	Description  string
 	IsDefault    bool
 	CreationTime util.ISO6801Time
+	RouterTableIds struct{
+		RouterTableIds []string
+	}
 }
 
 type DescribeVpcsResponse struct {

--- a/vendor/github.com/denverdino/aliyungo/metadata/client.go
+++ b/vendor/github.com/denverdino/aliyungo/metadata/client.go
@@ -44,7 +44,7 @@ const (
 	VSWITCH_CIDR_BLOCK = "vswitch-cidr-block"
 	VSWITCH_ID         = "vswitch-id"
 	ZONE               = "zone-id"
-	RAM_SECURITY       = "Ram/security-credentials"
+	RAM_SECURITY       = "ram/security-credentials"
 )
 
 type IMetaDataRequest interface {

--- a/vendor/github.com/denverdino/aliyungo/oss/client.go
+++ b/vendor/github.com/denverdino/aliyungo/oss/client.go
@@ -57,12 +57,14 @@ type Owner struct {
 // Options struct
 //
 type Options struct {
-	ServerSideEncryption bool
-	Meta                 map[string][]string
-	ContentEncoding      string
-	CacheControl         string
-	ContentMD5           string
-	ContentDisposition   string
+	ServerSideEncryption      bool
+	ServerSideEncryptionKeyID string
+
+	Meta               map[string][]string
+	ContentEncoding    string
+	CacheControl       string
+	ContentMD5         string
+	ContentDisposition string
 	//Range              string
 	//Expires int
 }
@@ -72,6 +74,9 @@ type CopyOptions struct {
 	CopySourceOptions string
 	MetadataDirective string
 	//ContentType       string
+
+	ServerSideEncryption      bool
+	ServerSideEncryptionKeyID string
 }
 
 // CopyObjectResult is the output from a Copy request
@@ -491,7 +496,10 @@ func (b *Bucket) PutFile(path string, file *os.File, perm ACL, options Options) 
 
 // addHeaders adds o's specified fields to headers
 func (o Options) addHeaders(headers http.Header) {
-	if o.ServerSideEncryption {
+	if len(o.ServerSideEncryptionKeyID) != 0 {
+		headers.Set("x-oss-server-side-encryption", "KMS")
+		headers.Set("x-oss-server-side-encryption-key-id", o.ServerSideEncryptionKeyID)
+	} else if o.ServerSideEncryption {
 		headers.Set("x-oss-server-side-encryption", "AES256")
 	}
 	if len(o.ContentEncoding) != 0 {
@@ -516,6 +524,13 @@ func (o Options) addHeaders(headers http.Header) {
 
 // addHeaders adds o's specified fields to headers
 func (o CopyOptions) addHeaders(headers http.Header) {
+	if len(o.ServerSideEncryptionKeyID) != 0 {
+		headers.Set("x-oss-server-side-encryption", "KMS")
+		headers.Set("x-oss-server-side-encryption-key-id", o.ServerSideEncryptionKeyID)
+	} else if o.ServerSideEncryption {
+		headers.Set("x-oss-server-side-encryption", "AES256")
+	}
+
 	if len(o.MetadataDirective) != 0 {
 		headers.Set("x-oss-metadata-directive", o.MetadataDirective)
 	}
@@ -836,6 +851,17 @@ func (b *Bucket) SignedURLWithArgs(path string, expires time.Time, params url.Va
 	return b.SignedURLWithMethod("GET", path, expires, params, headers)
 }
 
+func (b *Bucket) SignedURLWithMethodForAssumeRole(method, path string, expires time.Time, params url.Values, headers http.Header) string {
+	var uv = url.Values{}
+	if params != nil {
+		uv = params
+	}
+	if len(b.Client.SecurityToken) != 0 {
+		uv.Set("security-token", b.Client.SecurityToken)
+	}
+	return b.SignedURLWithMethod(method, path, expires, params, headers)
+}
+
 // SignedURLWithMethod returns a signed URL that allows anyone holding the URL
 // to either retrieve the object at path or make a HEAD request against it. The signature is valid until expires.
 func (b *Bucket) SignedURLWithMethod(method, path string, expires time.Time, params url.Values, headers http.Header) string {
@@ -1024,7 +1050,8 @@ func partiallyEscapedPath(path string) string {
 func (client *Client) prepare(req *request) error {
 	// Copy so they can be mutated without affecting on retries.
 	headers := copyHeader(req.headers)
-	if len(client.SecurityToken) != 0 {
+	// security-token should be in either Params or Header, cannot be in both
+	if len(req.params.Get("security-token")) == 0 && len(client.SecurityToken) != 0 {
 		headers.Set("x-oss-security-token", client.SecurityToken)
 	}
 

--- a/vendor/github.com/denverdino/aliyungo/oss/config_test.go
+++ b/vendor/github.com/denverdino/aliyungo/oss/config_test.go
@@ -16,8 +16,10 @@ import (
 //
 
 var (
-	TestAccessKeyId     = os.Getenv("AccessKeyId")
+	TestAccessKeyID     = os.Getenv("AccessKeyId")
 	TestAccessKeySecret = os.Getenv("AccessKeySecret")
 	TestSecurityToken   = os.Getenv("SecurityToken")
 	TestRegion          = oss.Region(os.Getenv("RegionId"))
+
+	TestServerSideEncryptionKeyID = os.Getenv("ServerSideEncryptionKeyId")
 )

--- a/vendor/github.com/denverdino/aliyungo/oss/signature.go
+++ b/vendor/github.com/denverdino/aliyungo/oss/signature.go
@@ -13,26 +13,44 @@ const HeaderOSSPrefix = "x-oss-"
 
 var ossParamsToSign = map[string]bool{
 	"acl":                          true,
+	"append":                       true,
+	"bucketInfo":                   true,
+	"cname":                        true,
+	"comp":                         true,
+	"cors":                         true,
 	"delete":                       true,
+	"endTime":                      true,
+	"img":                          true,
+	"lifecycle":                    true,
+	"live":                         true,
 	"location":                     true,
 	"logging":                      true,
-	"notification":                 true,
+	"objectMeta":                   true,
 	"partNumber":                   true,
-	"policy":                       true,
-	"requestPayment":               true,
-	"torrent":                      true,
-	"uploadId":                     true,
-	"uploads":                      true,
-	"versionId":                    true,
-	"versioning":                   true,
-	"versions":                     true,
-	"response-content-type":        true,
-	"response-content-language":    true,
-	"response-expires":             true,
+	"position":                     true,
+	"qos":                          true,
+	"referer":                      true,
+	"replication":                  true,
+	"replicationLocation":          true,
+	"replicationProgress":          true,
 	"response-cache-control":       true,
 	"response-content-disposition": true,
 	"response-content-encoding":    true,
-	"bucketInfo":                   true,
+	"response-content-language":    true,
+	"response-content-type":        true,
+	"response-expires":             true,
+	"security-token":               true,
+	"startTime":                    true,
+	"status":                       true,
+	"style":                        true,
+	"styleName":                    true,
+	"symlink":                      true,
+	"tagging":                      true,
+	"uploadId":                     true,
+	"uploads":                      true,
+	"vod":                          true,
+	"website":                      true,
+	"x-oss-process":                true,
 }
 
 func (client *Client) signRequest(request *request) {
@@ -62,7 +80,7 @@ func (client *Client) signRequest(request *request) {
 	}
 
 	if len(params) > 0 {
-		resource = resource + "?" + util.Encode(params)
+		resource = resource + "?" + util.EncodeWithoutEscape(params)
 	}
 
 	canonicalizedResource := resource
@@ -74,7 +92,7 @@ func (client *Client) signRequest(request *request) {
 	//log.Println("stringToSign: ", stringToSign)
 	signature := util.CreateSignature(stringToSign, client.AccessKeySecret)
 
-	if query.Get("OSSAccessKeyId") != "" {
+	if urlSignature {
 		query.Set("Signature", signature)
 	} else {
 		headers.Set("Authorization", "OSS "+client.AccessKeyId+":"+signature)

--- a/vendor/github.com/denverdino/aliyungo/pvtz/records.go
+++ b/vendor/github.com/denverdino/aliyungo/pvtz/records.go
@@ -152,7 +152,7 @@ type UpdateZoneRecordResponse struct {
 // UpdateZoneRecord update zone record
 //
 // You can read doc at https://help.aliyun.com/document_detail/66250.html
-func (client *Client) UpdateZoneRecord(args *AddZoneRecordArgs) (err error) {
+func (client *Client) UpdateZoneRecord(args *UpdateZoneRecordArgs) (err error) {
 	response := &UpdateZoneRecordResponse{}
 
 	err = client.Invoke("UpdateZoneRecord", args, &response)

--- a/vendor/github.com/denverdino/aliyungo/rds/instances.go
+++ b/vendor/github.com/denverdino/aliyungo/rds/instances.go
@@ -205,7 +205,6 @@ type CreateOrderResponse struct {
 }
 
 // CreateOrder create db instance order
-// you can read doc at http://docs.alibaba-inc.com/pages/viewpage.action?pageId=259349053
 func (client *Client) CreateOrder(args *CreateOrderArgs) (resp CreateOrderResponse, err error) {
 	response := CreateOrderResponse{}
 	err = client.Invoke("CreateOrder", args, &response)

--- a/vendor/github.com/denverdino/aliyungo/util/util.go
+++ b/vendor/github.com/denverdino/aliyungo/util/util.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	srand "crypto/rand"
 	"encoding/binary"
+	"encoding/json"
+	"fmt"
 	"math/rand"
 	"net/http"
 	"net/url"
 	"sort"
 	"time"
-	"fmt"
-	"encoding/json"
 )
 
 const dictionary = "_0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
@@ -60,6 +60,34 @@ func Encode(v url.Values) string {
 			if v != "" {
 				buf.WriteString("=")
 				buf.WriteString(url.QueryEscape(v))
+			}
+		}
+	}
+	return buf.String()
+}
+
+// Like Encode, but key and value are not escaped
+func EncodeWithoutEscape(v url.Values) string {
+	if v == nil {
+		return ""
+	}
+	var buf bytes.Buffer
+	keys := make([]string, 0, len(v))
+	for k := range v {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		vs := v[k]
+		prefix := k
+		for _, v := range vs {
+			if buf.Len() > 0 {
+				buf.WriteByte('&')
+			}
+			buf.WriteString(prefix)
+			if v != "" {
+				buf.WriteString("=")
+				buf.WriteString(v)
 			}
 		}
 	}
@@ -148,11 +176,10 @@ func GenerateRandomECSPassword() string {
 
 }
 
-
 func PrettyJson(object interface{}) string {
-	b,err := json.MarshalIndent(object,"", "    ")
+	b, err := json.MarshalIndent(object, "", "    ")
 	if err != nil {
-		fmt.Printf("ERROR: PrettyJson, %v\n %s\n",err,b)
+		fmt.Printf("ERROR: PrettyJson, %v\n %s\n", err, b)
 	}
 	return string(b)
 }


### PR DESCRIPTION
## Description
This PR make service with loadbalancer more powerful, we can use annotation to config aliyun private DNS service.

There are some samples:
```YAML
apiVersion: v1
kind: Service
metadata:
  labels:
    app: foo
  name: foo-service
  namespace: default
  annotations:
    service.beta.kubernetes.io/alicloud-loadbalancer-address-type: "intranet"
    service.beta.kubernetes.io/alicloud-loadbalancer-protocol-port: "http:80"
    service.beta.kubernetes.io/alicloud-private-zone-name: "service.ali"
    service.beta.kubernetes.io/alicloud-private-zone-record-name: "foo"
spec:
  ports:
    - port: 80
      protocol: TCP
      targetPort: 80
  selector:
    app: foo
  type: LoadBalancer
```
It will create new intranet SLB with a random IP, and create a `A record` bind the random IP to 'foo.service.ali'.
If your VPC has bound with the private zone 'service.ali', you can use 'http://foo.service.ali' to access your service in VPC, not a random IP.

![Snipaste_2019-03-25_16-03-06](https://user-images.githubusercontent.com/9367842/54903754-9a1dd800-4f17-11e9-932f-2a1520471893.png)

## Note
The service controller will not create private zone automatically, and users need to create it first to use those annotations.

The service controller will maintain DNS record automatically when service created, updated and deleted.

DNS record has caches with TTL, when you delete service and create it again, the service controller with update DNS record immediately. But, due to the cache, DNS record in ECS will not update quickly. The cache will be expired in TTL time, the default TTL is 60 second.

## Annotations
We support four annotations for configuring the private zone.

- service.beta.kubernetes.io/alicloud-private-zone-name  
The private zone name, a domain like string, "service.ali", "service.k8s" ...etc
- service.beta.kubernetes.io/alicloud-private-zone-id  
The private zone ID, service controller will find private zone by ID first
- service.beta.kubernetes.io/alicloud-private-zone-record-name  
The record name, a domain like string, "beta.foo", "foo" ...etc
- service.beta.kubernetes.io/alicloud-private-zone-record-ttl  
The record TTL, the default value is 60.