### PR TITLE
If it is Local mode, allow matar to join SLB

### DIFF
--- a/cloud-controller-manager/controller/service/service_controller.go
+++ b/cloud-controller-manager/controller/service/service_controller.go
@@ -934,7 +934,9 @@ func (s *ServiceController) getNodeConditionPredicate(service *v1.Service) (core
 		// As of 1.6, we will taint the master, but not necessarily mark it unschedulable.
 		// Recognize nodes labeled as master, and filter them also, as we were doing previously.
 		if _, hasMasterRoleLabel := node.Labels[LabelNodeRoleMaster]; hasMasterRoleLabel {
-			return false
+			if service.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeCluster {
+				return false
+			}
 		}
 
 		if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.ServiceNodeExclusion) {


### PR DESCRIPTION
If I deploy the program to the master node and the externalTrafficPolicy is set to Local, the SLB will not add the maste to the SLB, causing the service to be abnormal.