### PR TITLE
[ADD] add ModifyLoadBalancerInstanceSpec

### DIFF
--- a/cloud-controller-manager/loadbalancer.go
+++ b/cloud-controller-manager/loadbalancer.go
@@ -94,6 +94,7 @@ type ClientSLBSDK interface {
 	CreateLoadBalancer(args *slb.CreateLoadBalancerArgs) (response *slb.CreateLoadBalancerResponse, err error)
 	DeleteLoadBalancer(loadBalancerId string) (err error)
 	ModifyLoadBalancerInternetSpec(args *slb.ModifyLoadBalancerInternetSpecArgs) (err error)
+	ModifyLoadBalancerInstanceSpec(args *slb.ModifyLoadBalancerInstanceSpecArgs) (err error)
 	DescribeLoadBalancerAttribute(loadBalancerId string) (loadBalancer *slb.LoadBalancerType, err error)
 	RemoveBackendServers(loadBalancerId string, backendServers []string) (result []slb.BackendServerType, err error)
 	AddBackendServers(loadBalancerId string, backendServers []slb.BackendServerType) (result []slb.BackendServerType, err error)
@@ -398,22 +399,37 @@ func (s *LoadBalancerClient) EnsureLoadBalancer(service *v1.Service, nodes inter
 			glog.Infof("alicloud: bandwidth([%d] -> [%d]) changed, update loadbalancer [%s]\n",
 				origined.Bandwidth, request.Bandwidth, origined.LoadBalancerName)
 		}
-		if needUpdate {
-			if err := s.c.ModifyLoadBalancerInternetSpec(
-				&slb.ModifyLoadBalancerInternetSpecArgs{
-					LoadBalancerId:     origined.LoadBalancerId,
-					InternetChargeType: charge,
-					Bandwidth:          bandwidth,
-				}); err != nil {
-				return nil, err
-			}
-		}
 		if request.AddressType != "" && request.AddressType != origined.AddressType {
 			glog.Errorf("alicloud: warning! can not change "+
 				"loadbalancer address type after it has been created! please "+
 				"recreate the service.[%s]->[%s],[%s]\n", origined.AddressType, request.AddressType, origined.LoadBalancerName)
 			return nil, errors.New("alicloud: change loadbalancer " +
 				"address type after service has been created is not supported. delete and retry")
+		}
+		if needUpdate {
+			if origined.AddressType == "internet" {
+				if err := s.c.ModifyLoadBalancerInternetSpec(
+					&slb.ModifyLoadBalancerInternetSpecArgs{
+						LoadBalancerId:     origined.LoadBalancerId,
+						InternetChargeType: charge,
+						Bandwidth:          bandwidth,
+					}); err != nil {
+					return nil, err
+				}
+			}
+		}
+
+		// update instance spec
+		if request.LoadBalancerSpec != "" && request.LoadBalancerSpec != origined.LoadBalancerSpec {
+			glog.Infof("alicloud: loadbalancerspec([%s] -> [%s]) changed, update loadbalancer [%s]\n",
+				origined.LoadBalancerSpec, request.LoadBalancerSpec, origined.LoadBalancerName)
+			if err := s.c.ModifyLoadBalancerInstanceSpec(&slb.ModifyLoadBalancerInstanceSpecArgs{
+				RegionId:         origined.RegionId,
+				LoadBalancerId:   origined.LoadBalancerId,
+				LoadBalancerSpec: request.LoadBalancerSpec,
+			}); err != nil {
+				return nil, err
+			}
 		}
 		origined, derr = s.c.DescribeLoadBalancerAttribute(origined.LoadBalancerId)
 	}

--- a/cloud-controller-manager/loadbalancer_mock.go
+++ b/cloud-controller-manager/loadbalancer_mock.go
@@ -67,6 +67,7 @@ type mockClientSLB struct {
 	createLoadBalancer             func(args *slb.CreateLoadBalancerArgs) (response *slb.CreateLoadBalancerResponse, err error)
 	deleteLoadBalancer             func(loadBalancerId string) (err error)
 	modifyLoadBalancerInternetSpec func(args *slb.ModifyLoadBalancerInternetSpecArgs) (err error)
+	modifyLoadBalancerInstanceSpec func(args *slb.ModifyLoadBalancerInstanceSpecArgs) (err error)
 	describeLoadBalancerAttribute  func(loadBalancerId string) (loadBalancer *slb.LoadBalancerType, err error)
 	removeBackendServers           func(loadBalancerId string, backendServers []string) (result []slb.BackendServerType, err error)
 	addBackendServers              func(loadBalancerId string, backendServers []slb.BackendServerType) (result []slb.BackendServerType, err error)
@@ -129,6 +130,7 @@ func newBaseLoadbalancer() []*slb.LoadBalancerType {
 			InternetChargeType: "4",
 			CreateTime:         "2018-03-14T17:16Z",
 			CreateTimeStamp:    util.NewISO6801Time(time.Now()),
+			LoadBalancerSpec:   slb.S1Small,
 		},
 	}
 }
@@ -233,6 +235,7 @@ func (c *mockClientSLB) DeleteLoadBalancer(loadBalancerId string) (err error) {
 	LOADBALANCER.loadbalancer.Delete(loadBalancerId)
 	return nil
 }
+
 func (c *mockClientSLB) ModifyLoadBalancerInternetSpec(args *slb.ModifyLoadBalancerInternetSpecArgs) (err error) {
 	if c.modifyLoadBalancerInternetSpec != nil {
 		return c.modifyLoadBalancerInternetSpec(args)
@@ -255,6 +258,12 @@ func (c *mockClientSLB) ModifyLoadBalancerInternetSpec(args *slb.ModifyLoadBalan
 		ins.InternetChargeType = args.InternetChargeType
 	}
 	LOADBALANCER.loadbalancer.Store(ins.LoadBalancerId, ins)
+	return nil
+}
+func (c *mockClientSLB) ModifyLoadBalancerInstanceSpec(args *slb.ModifyLoadBalancerInstanceSpecArgs) (err error) {
+	if c.modifyLoadBalancerInstanceSpec != nil {
+		return c.modifyLoadBalancerInstanceSpec(args)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Rebuit [PR61](https://github.com/kubernetes/cloud-provider-alibaba-cloud/pull/61) since there was a conflict in it.

---

For now, aliyun cloud-controller-manager does not support change loadbalancer instace spec.
This PR enables changing loadbalancer instace spec throught changing service annotation service.beta.kubernetes.io/alicloud-loadbalancer-spec.
