### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .idea
-./build/alicloud-controller-manager
 projectFilesBackup/
 coverage.txt
-alicloud-controller-manager
+alibaba-cloud-ccm


### PR DESCRIPTION
/kind bug

Update .gitignore to ignore the binary built by `make cloud-controller-manager`.

