### PR TITLE
update default go version to 1.17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ KIND_BINARY_NAME?=cloud-controller-manager
 # use the official module proxy by default
 GOPROXY?=https://goproxy.cn,direct
 # default build image
-GO_VERSION?=1.16
+GO_VERSION?=1.17
 GO_IMAGE?=golang:$(GO_VERSION)
 # docker volume name, used as a go module / build cache
 CACHE_VOLUME?=cloud-controller-manager-build-cache

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,7 +2,7 @@
 
 ## Alibaba Cloud Provider introduction
 
-**CloudProvider** provides the Cloud Provider interface implementation as an out-of-tree cloud-controller-manager. It allows Kubernetes clusters to leverage the infrastructure services of Alibaba Cloud .<br />It is original open sourced project is [https://github.com/AliyunContainerService/alibaba-cloud-controller-manager](https://github.com/AliyunContainerService/alibaba-cloud-controller-manager)<br />[See ReleaseNotes](https://yq.aliyun.com/articles/608575)<br />**Basic usage** cloudprovider use service annotation to control service creation behavior. Here is a basic annotation example:
+**CloudProvider** provides the Cloud Provider interface implementation as an out-of-tree cloud-controller-manager. It allows Kubernetes clusters to leverage the infrastructure services of Alibaba Cloud .<br />It is original open sourced project is [https://github.com/AliyunContainerService/alicloud-controller-manager](https://github.com/AliyunContainerService/alicloud-controller-manager)<br />[See ReleaseNotes](https://yq.aliyun.com/articles/608575)<br />**Basic usage** cloudprovider use service annotation to control service creation behavior. Here is a basic annotation example:
 
 ```
 apiVersion: v1
@@ -32,7 +32,7 @@ root@master # kubectl get po -n kube-system -o yaml|grep image:|grep cloud-con|u
 image: registry-vpc.cn-....-controller-manager-amd64:v1.9.3
 ```
 
-- Some features might not be usable until you upgrade your cloud-controller-manager to the latest version. See[manaully upgrade CloudProvider](https://yq.aliyun.com/articles/608563?spm=a2c4e.11153940.blogrightarea608575.9.57ed1279saZghW)。
+- Some features might not be usable until you upgrade your cloud-controller-manager to the latest version. See [manaully upgrade CloudProvider](https://yq.aliyun.com/articles/608563?spm=a2c4e.11153940.blogrightarea608575.9.57ed1279saZghW)。
 
 ## How to create service with Type=LoadBalancer
 


### PR DESCRIPTION
Fix build error, update default go version from 1.16 to 1.17 and update invalid url
make error message:
```
# sigs.k8s.io/json/internal/golang/encoding/json
vendor/sigs.k8s.io/json/internal/golang/encoding/json/encode.go:1249:12: sf.IsExported undefined (type reflect.StructField has no field or method IsExported)
vendor/sigs.k8s.io/json/internal/golang/encoding/json/encode.go:1255:18: sf.IsExported undefined (type reflect.StructField has no field or method IsExported)

```