### PR TITLE
fix wrong cluster id

### DIFF
--- a/pkg/config/cloud_config.go
+++ b/pkg/config/cloud_config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/ghodss/yaml"
 	"io/ioutil"
+	"k8s.io/cloud-provider-alibaba-cloud/pkg/util"
 	"k8s.io/klog/v2"
 )
 
@@ -48,14 +49,14 @@ func (cc *CloudConfig) LoadCloudCFG() error {
 	if err != nil {
 		return fmt.Errorf("read cloud config error: %s ", err.Error())
 	}
-	// set default value
-	if cc.Global.KubernetesClusterTag == "" {
-		cc.Global.KubernetesClusterTag = "ack.aliyun.com"
-	}
-	if cc.Global.ClusterID == "" {
-		cc.Global.ClusterID = "clusterid"
-	}
 	return yaml.Unmarshal(content, CloudCFG)
+}
+
+func (cc *CloudConfig) GetKubernetesClusterTag() string {
+	if cc.Global.KubernetesClusterTag == "" {
+		return util.ClusterTagKey
+	}
+	return cc.Global.KubernetesClusterTag
 }
 
 func (cc *CloudConfig) PrintInfo() {

--- a/pkg/controller/ingress/reconcile/applier/service.go
+++ b/pkg/controller/ingress/reconcile/applier/service.go
@@ -80,7 +80,7 @@ func (m *defaultServiceManagerApplier) Apply(ctx context.Context, albProvider pr
 
 func NewServiceStackApplier(albProvider prvd.Provider, serviceStack *albmodel.ServiceManager, logger logr.Logger) *serviceStackApplier {
 	tagFilters := make(map[string]string)
-	tagFilters[util.ClusterNameTagKey] = serviceStack.ClusterID
+	tagFilters[util.ClusterTagKey] = serviceStack.ClusterID
 	tagFilters[util.ServiceNamespaceTagKey] = serviceStack.Namespace
 	tagFilters[util.ServiceNameTagKey] = serviceStack.Name
 
@@ -181,7 +181,7 @@ func mapSDKServerGroupByResourceID(sdkSGPs []albmodel.ServerGroupWithTags) map[s
 		var svcNameKey albmodel.ServerGroupNamedKey
 
 		tags := sdkSGP.Tags
-		if v, ok := tags[util.ClusterNameTagKey]; ok {
+		if v, ok := tags[util.ClusterTagKey]; ok {
 			svcNameKey.ClusterID = v
 		} else {
 			continue

--- a/pkg/controller/ingress/reconcile/tracking/tracking.go
+++ b/pkg/controller/ingress/reconcile/tracking/tracking.go
@@ -43,7 +43,7 @@ func (p *defaultTrackingProvider) AlbConfigTagKey() string {
 }
 
 func (p *defaultTrackingProvider) ClusterNameTagKey() string {
-	return util.ClusterNameTagKey
+	return util.ClusterTagKey
 }
 
 func (p *defaultTrackingProvider) StackTags(stack core.Manager) map[string]string {

--- a/pkg/controller/service/annotations.go
+++ b/pkg/controller/service/annotations.go
@@ -5,8 +5,9 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
-	ctrlCfg "k8s.io/cloud-provider-alibaba-cloud/pkg/config"
 	"k8s.io/cloud-provider-alibaba-cloud/pkg/model"
+	"k8s.io/cloud-provider-alibaba-cloud/pkg/provider/alibaba/base"
+	"k8s.io/cloud-provider-alibaba-cloud/pkg/util"
 )
 
 // prefix
@@ -144,8 +145,8 @@ func (n *AnnotationRequest) GetDefaultTags() []model.Tag {
 			TagValue: n.GetDefaultLoadBalancerName(),
 		},
 		{
-			TagKey:   ctrlCfg.CloudCFG.Global.KubernetesClusterTag,
-			TagValue: ctrlCfg.CloudCFG.Global.ClusterID,
+			TagKey:   util.ClusterTagKey,
+			TagValue: base.CLUSTER_ID,
 		},
 	}
 }

--- a/pkg/controller/service/helper.go
+++ b/pkg/controller/service/helper.go
@@ -8,6 +8,7 @@ import (
 	ctrlCfg "k8s.io/cloud-provider-alibaba-cloud/pkg/config"
 	"k8s.io/cloud-provider-alibaba-cloud/pkg/controller/helper"
 	"k8s.io/cloud-provider-alibaba-cloud/pkg/model"
+	"k8s.io/cloud-provider-alibaba-cloud/pkg/util"
 	"k8s.io/cloud-provider-alibaba-cloud/pkg/util/hash"
 	"k8s.io/klog/v2"
 	"os"
@@ -125,7 +126,9 @@ func isServiceHashChanged(service *v1.Service) bool {
 
 func isLoadBalancerReusable(service *v1.Service, tags []model.Tag, lbIp string) (bool, string) {
 	for _, tag := range tags {
-		if tag.TagKey == TAGKEY || tag.TagKey == ctrlCfg.CloudCFG.Global.KubernetesClusterTag {
+		// the tag of the apiserver slb is "ack.aliyun.com": "${clusterid}",
+		// so can not reuse slbs which have ack.aliyun.com tag key.
+		if tag.TagKey == TAGKEY || tag.TagKey == util.ClusterTagKey {
 			return false, "can not reuse loadbalancer created by kubernetes."
 		}
 	}

--- a/pkg/provider/alibaba/base/clientMgr.go
+++ b/pkg/provider/alibaba/base/clientMgr.go
@@ -83,6 +83,7 @@ func NewClientMgr() (*ClientMgr, error) {
 	}
 
 	meta := NewMetaData()
+	CLUSTER_ID = meta.ClusterID()
 	region, err := meta.Region()
 	if err != nil {
 		return nil, fmt.Errorf("can not determin region: %s", err.Error())

--- a/pkg/provider/alibaba/base/metadata.go
+++ b/pkg/provider/alibaba/base/metadata.go
@@ -584,7 +584,7 @@ func (m *CfgMetaData) RamRoleToken(role string) (prvd.RoleAuth, error) {
 
 func (m *CfgMetaData) ClusterID() string {
 	if ctrlCfg.CloudCFG.Global.ClusterID != "" {
-		CLUSTER_ID = ctrlCfg.CloudCFG.Global.ClusterID
+		return ctrlCfg.CloudCFG.Global.ClusterID
 	}
 	return CLUSTER_ID
 }

--- a/pkg/provider/alibaba/ecs/ecs.go
+++ b/pkg/provider/alibaba/ecs/ecs.go
@@ -85,8 +85,7 @@ func (e *ECSProvider) GetInstancesByIP(ctx context.Context, ips []string) (*prvd
 	}
 	req.Tag = &[]ecs.DescribeInstancesTag{
 		{
-			Key:   ctrlCfg.CloudCFG.Global.KubernetesClusterTag,
-			Value: ctrlCfg.CloudCFG.Global.ClusterID,
+			Key: ctrlCfg.CloudCFG.GetKubernetesClusterTag(),
 		},
 	}
 	resp, err := e.auth.ECS.DescribeInstances(req)

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -171,7 +171,7 @@ const ConcurrentMaxSleepMillisecondTime = 200
 const IndexKeyServiceRefName = "spec.serviceRef.name"
 
 const (
-	ClusterNameTagKey      = "ack.aliyun.com"
+	ClusterTagKey          = "ack.aliyun.com"
 	ServiceNamespaceTagKey = IngressTagKeyPrefix + "/service_ns"
 	ServiceNameTagKey      = IngressTagKeyPrefix + "/service_name"
 	ServicePortTagKey      = IngressTagKeyPrefix + "/service_port"


### PR DESCRIPTION
Kind of BugFix

The cluster id is always “clusterid” even if setting the --cluster-id param in cloud config file. 