### PR TITLE
[Bug] Optimize ZoneMappings comparison

### DIFF
--- a/pkg/controller/service/nlbv2/loadbalancer.go
+++ b/pkg/controller/service/nlbv2/loadbalancer.go
@@ -140,25 +140,22 @@ func (mgr *NLBManager) Update(reqCtx *svcCtx.RequestContext, local, remote *nlbm
 		}
 	}
 
-	needUpdate := false
 	for _, l := range local.LoadBalancerAttribute.ZoneMappings {
-		found := false
+		match := false
 		for _, r := range remote.LoadBalancerAttribute.ZoneMappings {
-			if l.ZoneId == r.ZoneId && l.VSwitchId == r.VSwitchId {
-				found = true
+			if l.ZoneId == r.ZoneId && l.VSwitchId == r.VSwitchId &&
+				l.IPv4Addr == r.IPv4Addr && l.AllocationId == r.AllocationId {
+				match = true
 				break
 			}
 		}
-		if !found {
-			needUpdate = true
+		if !match {
+			reqCtx.Log.Info(fmt.Sprintf("ZoneMappings changed from [%s] to [%s]",
+				remote.LoadBalancerAttribute.ZoneMappings, local.LoadBalancerAttribute.ZoneMappings))
+			if err := mgr.cloud.UpdateNLBZones(reqCtx.Ctx, local); err != nil {
+				errs = append(errs, fmt.Errorf("update zone mappings error: %s", err.Error()))
+			}
 			break
-		}
-	}
-	if needUpdate {
-		reqCtx.Log.Info(fmt.Sprintf("ZoneMappings changed from [%s] to [%s]",
-			remote.LoadBalancerAttribute.ZoneMappings, local.LoadBalancerAttribute.ZoneMappings))
-		if err := mgr.cloud.UpdateNLBZones(reqCtx.Ctx, local); err != nil {
-			errs = append(errs, fmt.Errorf("update zone mappings error: %s", err.Error()))
 		}
 	}
 

--- a/pkg/controller/service/nlbv2/loadbalancer.go
+++ b/pkg/controller/service/nlbv2/loadbalancer.go
@@ -143,10 +143,11 @@ func (mgr *NLBManager) Update(reqCtx *svcCtx.RequestContext, local, remote *nlbm
 	for _, l := range local.LoadBalancerAttribute.ZoneMappings {
 		match := false
 		for _, r := range remote.LoadBalancerAttribute.ZoneMappings {
-			if l.ZoneId == r.ZoneId && l.VSwitchId == r.VSwitchId &&
-				l.IPv4Addr == r.IPv4Addr && l.AllocationId == r.AllocationId {
-				match = true
-				break
+			if l.ZoneId == r.ZoneId && l.VSwitchId == r.VSwitchId {
+				if l.AllocationId == "" || l.AllocationId != "" && l.AllocationId == r.AllocationId {
+					match = true
+					break
+				}
 			}
 		}
 		if !match {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
https://www.alibabacloud.com/help/en/slb/network-load-balancer/developer-reference/api-nlb-2022-04-30-updateloadbalancerzones

6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
If the annotation [`ZoneMaps`](https://github.com/kubernetes/cloud-provider-alibaba-cloud/blob/master/pkg/controller/service/nlbv2/loadbalancer.go#L32) exists,  we should take into account; enhances reconciliation of load balancers by including public IP comparison, aligning with Alicloud's documentation and the existing implementation for `ZoneMappings` updates.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/cloud-provider-alibaba-cloud/issues/385

#### Special notes for your reviewer:
The [UpdateLoadBalancerZones](https://www.alibabacloud.com/help/en/slb/network-load-balancer/developer-reference/api-nlb-2022-04-30-updateloadbalancerzones?spm=a2c63.p38356.0.0.754e4f52ajAGHE) function allows for the modification of Public IPs when reconciling load balancers.
Meanwhile, [UpdateNLBZones](https://github.com/kubernetes/cloud-provider-alibaba-cloud/blob/85a239e6ace31d9966f3ccf28aa43f99db0a2178/pkg/provider/alibaba/nlb/loadbalancer.go#L178-L183) has already supported this feature.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
