### PR TITLE
feat: add nlb HealthCheckHttpVersion annotation

### DIFF
--- a/pkg/controller/service/nlbv2/server_groups.go
+++ b/pkg/controller/service/nlbv2/server_groups.go
@@ -447,6 +447,13 @@ func (mgr *ServerGroupManager) UpdateServerGroup(reqCtx *svcCtx.RequestContext, 
 				updateDetail += fmt.Sprintf("HealthCheckHttpCode %v should be changed to %v;",
 					remoteHC.HealthCheckHttpCode, localHC.HealthCheckHttpCode)
 			}
+			if localHC.HealthCheckHttpVersion != "" &&
+				!strings.EqualFold(localHC.HealthCheckHttpVersion, remoteHC.HealthCheckHttpVersion) {
+				needUpdate = true
+				update.HealthCheckConfig.HealthCheckHttpVersion = localHC.HealthCheckHttpVersion
+				updateDetail += fmt.Sprintf("HealthCheckHttpVersion %v should be changed to %v;",
+					remoteHC.HealthCheckHttpVersion, localHC.HealthCheckHttpVersion)
+			}
 
 		}
 	update:
@@ -1286,6 +1293,7 @@ func setServerGroupAttributeFromAnno(sg *nlbmodel.ServerGroup, anno *annotation.
 			healthCheckConfig.HealthCheckDomain = anno.Get(annotation.HealthCheckDomain)
 			healthCheckConfig.HealthCheckUrl = anno.Get(annotation.HealthCheckURI)
 			healthCheckConfig.HttpCheckMethod = anno.Get(annotation.HealthCheckMethod)
+			healthCheckConfig.HealthCheckHttpVersion = anno.Get(annotation.HealthCheckHttpVersion)
 			if anno.Get(annotation.HealthCheckHTTPCode) != "" {
 				healthCheckConfig.HealthCheckHttpCode = strings.Split(anno.Get(annotation.HealthCheckHTTPCode), ",")
 			}

--- a/pkg/controller/service/reconcile/annotation/annotations.go
+++ b/pkg/controller/service/reconcile/annotation/annotations.go
@@ -84,6 +84,7 @@ const (
 	HealthCheckDomain          = AnnotationLoadBalancerPrefix + "health-check-domain"          // HealthCheckDomain health check domain
 	HealthCheckHTTPCode        = AnnotationLoadBalancerPrefix + "health-check-httpcode"        // HealthCheckHTTPCode health check http code
 	HealthCheckMethod          = AnnotationLoadBalancerPrefix + "health-check-method"          // HealthCheckMethod health check method for L7
+	HealthCheckHttpVersion     = AnnotationLoadBalancerPrefix + "health-check-http-version"    // HealthCheckHttpVersion health check http protocol version, HTTP1.0 or HTTP1.1
 	SessionStick               = AnnotationLoadBalancerPrefix + "sticky-session"               // SessionStick sticky session
 	SessionStickType           = AnnotationLoadBalancerPrefix + "sticky-session-type"          // SessionStickType session sticky type
 	CookieTimeout              = AnnotationLoadBalancerPrefix + "cookie-timeout"               // CookieTimeout cookie timeout

--- a/pkg/model/nlb/nlb.go
+++ b/pkg/model/nlb/nlb.go
@@ -287,6 +287,7 @@ type HealthCheckConfig struct {
 	HealthCheckUrl            string
 	HealthCheckHttpCode       []string
 	HttpCheckMethod           string
+	HealthCheckHttpVersion    string
 }
 
 type NamedKey struct {

--- a/pkg/provider/alibaba/nlb/servergroup.go
+++ b/pkg/provider/alibaba/nlb/servergroup.go
@@ -44,6 +44,7 @@ func (p *NLBProvider) toLocalServerGroup(ctx context.Context, remote *nlb.ListSe
 			HealthCheckDomain:         tea.StringValue(remote.HealthCheck.HealthCheckDomain),
 			HealthCheckUrl:            tea.StringValue(remote.HealthCheck.HealthCheckUrl),
 			HttpCheckMethod:           tea.StringValue(remote.HealthCheck.HttpCheckMethod),
+			HealthCheckHttpVersion:    tea.StringValue(remote.HealthCheck.HealthCheckHttpVersion),
 		}
 		if len(remote.HealthCheck.HealthCheckHttpCode) != 0 {
 			for _, code := range remote.HealthCheck.HealthCheckHttpCode {
@@ -335,6 +336,9 @@ func (p *NLBProvider) CreateNLBServerGroupAsync(ctx context.Context, sg *nlbmode
 		if sg.HealthCheckConfig.HttpCheckMethod != "" {
 			req.HealthCheckConfig.HttpCheckMethod = tea.String(sg.HealthCheckConfig.HttpCheckMethod)
 		}
+		if sg.HealthCheckConfig.HealthCheckHttpVersion != "" {
+			req.HealthCheckConfig.HealthCheckHttpVersion = tea.String(sg.HealthCheckConfig.HealthCheckHttpVersion)
+		}
 		if len(sg.HealthCheckConfig.HealthCheckHttpCode) != 0 {
 			for _, code := range sg.HealthCheckConfig.HealthCheckHttpCode {
 				req.HealthCheckConfig.HealthCheckHttpCode = append(req.HealthCheckConfig.HealthCheckHttpCode,
@@ -429,6 +433,9 @@ func (p *NLBProvider) UpdateNLBServerGroupAsync(ctx context.Context, sg *nlbmode
 		}
 		if sg.HealthCheckConfig.HttpCheckMethod != "" {
 			req.HealthCheckConfig.HttpCheckMethod = tea.String(sg.HealthCheckConfig.HttpCheckMethod)
+		}
+		if sg.HealthCheckConfig.HealthCheckHttpVersion != "" {
+			req.HealthCheckConfig.HealthCheckHttpVersion = tea.String(sg.HealthCheckConfig.HealthCheckHttpVersion)
 		}
 		if len(sg.HealthCheckConfig.HealthCheckHttpCode) != 0 {
 			for _, code := range sg.HealthCheckConfig.HealthCheckHttpCode {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds a new annotation service.beta.kubernetes.io/alibaba-cloud-loadbalancer-health-check-http-version to allow users to specify the HTTP protocol version (HTTP1.0 or HTTP1.1) for NLB health checks. The value is applied to the ServerGroup's HealthCheckConfig.HealthCheckHttpVersion on create, update, and reconcile.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NLB health checks now support configuring HTTP protocol version via the `service.beta.kubernetes.io/alibaba-cloud-loadbalancer-health-check-http-version` annotation (values: `HTTP1.0`, `HTTP1.1`).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
